### PR TITLE
(PE-3443) Fix refer-clojure typo in sync.clj

### DIFF
--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -3,7 +3,7 @@
 
 (ns puppetlabs.http.client.sync
   (:require [puppetlabs.http.client.async :as async])
-  (:refer-clojure :exclute (get)))
+  (:refer-clojure :exclude (get)))
 
 (defn request
   [req]


### PR DESCRIPTION
Fixed typo in sync.clj in the (:refer-clojure) argument to ns.  :exclute
is now :exclude and the prior warning about references from
puppetlabs.http.client.sync/get overriding clojure.core/get is now
suppressed.
