### PR TITLE
(doc) Update README to link to Apache HttpAsyncClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # puppetlabs/http-client
 
-This is a wrapper around the [http-kit](http://http-kit.org/) client
-providing some extra functionality for configuring SSL in a way
-compatible with Puppet.
+This is a wrapper around the [Apache HttpAsyncClient
+library](http://hc.apache.org/httpcomponents-asyncclient-4.0.x/) providing
+some extra functionality for configuring SSL in a way compatible with Puppet.
 
 Async versions of the http methods are exposed in
 puppetlabs.http.client.async, and synchronous versions are in


### PR DESCRIPTION
Previously, this library was a wrapper around http-kit, but has since been
updated to use the Apache HttpAsyncClient library instead. This commit updates
the README to link to HttpAsyncClient rather than http-kit.
