### PR TITLE
(PE-5567) Fix bug if content-type header has no charset

### DIFF
--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -256,12 +256,12 @@ public class JavaClient {
         }
     }
 
-    private static Object coerceBodyType(InputStream body, ResponseBodyType as,
+    public static Object coerceBodyType(InputStream body, ResponseBodyType as,
                                          ContentType contentType) {
         switch (as) {
             case TEXT:
                 String charset = "UTF-8";
-                if (contentType != null) {
+                if ((contentType != null) && (contentType.getCharset() != null)) {
                     charset = contentType.getCharset().name();
                 }
                 try {

--- a/test/com/puppetlabs/http/client/impl/java_client_test.clj
+++ b/test/com/puppetlabs/http/client/impl/java_client_test.clj
@@ -1,0 +1,20 @@
+(ns com.puppetlabs.http.client.impl.java-client-test
+  (:import (com.puppetlabs.http.client.impl JavaClient)
+           (org.apache.commons.io IOUtils)
+           (com.puppetlabs.http.client ResponseBodyType)
+           (org.apache.http.entity ContentType))
+  (:require [clojure.test :refer :all]))
+
+;; NOTE: there are more comprehensive, end-to-end tests for
+;; the Java client functionality lumped in with the clojure
+;; tests.  This namespace is just for some edge-casey,
+;; Java-only unit tests.
+
+(deftest test-coerce-body-type
+  (testing "Can handle a Content Type header with no charset"
+    (let [body "foo"
+          body-stream (IOUtils/toInputStream body "UTF-8")]
+      (is (= "foo" (JavaClient/coerceBodyType
+                     body-stream
+                     ResponseBodyType/TEXT
+                     ContentType/WILDCARD))))))


### PR DESCRIPTION
Prior to this commit, the Java client API would throw an NPE if
it got a response from a server where the Content-Type header
did not include a charset.
