### PR TITLE
Add RequestOptions constructor with string

### DIFF
--- a/src/java/com/puppetlabs/http/client/RequestOptions.java
+++ b/src/java/com/puppetlabs/http/client/RequestOptions.java
@@ -8,6 +8,7 @@ import org.apache.http.nio.client.HttpAsyncClient;
 
 import javax.net.ssl.SSLContext;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 public class RequestOptions {
@@ -26,6 +27,7 @@ public class RequestOptions {
     private ResponseBodyType as = ResponseBodyType.STREAM;
     private Map<String, String> queryParams;
 
+    public RequestOptions (String url) throws URISyntaxException { this.uri = new URI(url); }
     public RequestOptions(URI uri) {
         this.uri = uri;
     }

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -33,7 +33,7 @@
         [jetty9/jetty9-service test-web-service]
         {:webserver {:port 10000}}
         (testing "java async client"
-          (let [options (RequestOptions. (URI. "http://localhost:10000/hello/"))
+          (let [options (RequestOptions. "http://localhost:10000/hello/")
                 response (java-method options)]
             (is (= 200 (.getStatus (.deref response))))
             (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))


### PR DESCRIPTION
Add a RequestOptions constructor that takes a string instead
of a URI. Modify the basic-test function to use the string
constructor.
