### PR TITLE
(PE-6019) Set request body character encoding to UTF-8

### DIFF
--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -19,7 +19,7 @@
            (org.apache.http.client.utils URIBuilder)
            (org.apache.http.concurrent FutureCallback)
            (org.apache.http.message BasicHeader)
-           (org.apache.http Header)
+           (org.apache.http Consts Header)
            (org.apache.http.nio.entity NStringEntity)
            (org.apache.http.entity InputStreamEntity ContentType)
            (java.io InputStream)
@@ -112,7 +112,7 @@
      :method  (clojure.core/get opts :method :get)
      :headers (prepare-headers opts)
      :body    (cond
-                (string? body) (NStringEntity. body)
+                (string? body) (NStringEntity. body Consts/UTF_8)
                 (instance? InputStream body) (InputStreamEntity. body)
                 :else body)}))
 

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -70,11 +70,8 @@ public class JavaClient {
         HttpEntity body = null;
 
         if (options.getBody() instanceof String) {
-            try {
-                body = new NStringEntity((String)options.getBody());
-            } catch (UnsupportedEncodingException e) {
-                throw new HttpClientException("Unable to create request body", e);
-            }
+            body = new NStringEntity((String)options.getBody(),
+                    Consts.UTF_8);
         } else if (options.getBody() instanceof InputStream) {
             body = new InputStreamEntity((InputStream)options.getBody());
         }


### PR DESCRIPTION
This commit sets the character encoding for the body of a request to
UTF-8.  Previous code did not set a character encoding and so a default
of ISO-8859-1 was implicitly used.  This change assumes that UTF-8 is a
more reasonable default for clients although work should be done later
to make this externally configurable.
