### PR TITLE
(TK-88) Removed errant build call from JavaClient's createClient()

### DIFF
--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -231,7 +231,7 @@ public class JavaClient {
     private static CloseableHttpAsyncClient createClient(CoercedRequestOptions coercedOptions) {
         HttpAsyncClientBuilder clientBuilder = HttpAsyncClients.custom();
         if (coercedOptions.getSslContext() != null) {
-            clientBuilder.setSSLContext(coercedOptions.getSslContext()).build();
+            clientBuilder.setSSLContext(coercedOptions.getSslContext());
         }
         RedirectStrategy redirectStrategy;
         if (!coercedOptions.getFollowRedirects()) {


### PR DESCRIPTION
This commit removes an unnecessary build() method call made on the
HttpAsyncClientBuilder in JavaClient's createClient() method.
Previously, the presence of this call would cause an extra
CloseableHttpAsyncClient object to be created.  Since close() was never
called on the extra client object, native file descriptor resources were
never freed even after the object fell out of scope.
