### PR TITLE
(SERVER-101) Update jvm-ca dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.lein-failures

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
 (def ks-version "1.0.0")
-(def tk-version "0.5.1")
+(def tk-version "1.0.1")
 
 (defproject puppetlabs/http-client "0.4.1-SNAPSHOT"
   :description "HTTP client wrapper"

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,7 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/clojure "1.5.1"]
-                 [puppetlabs/certificate-authority "0.6.0"]
+                 [puppetlabs/ssl-utils "0.7.0"]
                  [org.clojure/tools.logging "0.2.6"]
                  [puppetlabs/kitchensink ~ks-version]
                  [org.slf4j/slf4j-api "1.7.6"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def ks-version "0.7.2")
+(def ks-version "1.0.0")
 (def tk-version "0.5.1")
 
 (defproject puppetlabs/http-client "0.4.1-SNAPSHOT"

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -7,7 +7,7 @@
 ;; (:ssl-cert :ssl-key :ssl-ca-cert) to create the SSLContext. It is also
 ;; still possible to use an SSLEngine directly, and if this is present under
 ;; the key :sslengine it will be used before any other options are tried.
-;; 
+;;
 ;; See the puppetlabs.http.sync namespace for synchronous versions of all
 ;; these methods.
 
@@ -29,7 +29,7 @@
            (org.apache.http.impl.client LaxRedirectStrategy DefaultRedirectStrategy)
            (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
            (org.apache.http.conn.ssl SSLContexts))
-  (:require [puppetlabs.certificate-authority.core :as ssl]
+  (:require [puppetlabs.ssl-utils.core :as ssl]
             [clojure.string :as str]
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.http.client.common :as common]

--- a/src/java/com/puppetlabs/http/client/impl/SslUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/SslUtils.java
@@ -1,6 +1,6 @@
 package com.puppetlabs.http.client.impl;
 
-import com.puppetlabs.certificate_authority.CertificateAuthority;
+import com.puppetlabs.ssl_utils.SSLUtils;
 import com.puppetlabs.http.client.HttpClientException;
 import com.puppetlabs.http.client.ClientOptions;
 import com.puppetlabs.http.client.Sync;
@@ -33,7 +33,7 @@ public class SslUtils {
                 (options.getSslCaCert() != null)) {
             try {
                 options.setSslContext(
-                        CertificateAuthority.pemsToSSLContext(
+                        SSLUtils.pemsToSSLContext(
                                 new FileReader(options.getSslCert()),
                                 new FileReader(options.getSslKey()),
                                 new FileReader(options.getSslCaCert()))
@@ -60,7 +60,7 @@ public class SslUtils {
         if (options.getSslCaCert() != null) {
             try {
                 options.setSslContext(
-                        CertificateAuthority.caCertPemToSSLContext(
+                        SSLUtils.caCertPemToSSLContext(
                                 new FileReader(options.getSslCaCert()))
                 );
             } catch (KeyStoreException e) {

--- a/test/puppetlabs/http/client/async_ssl_config_test.clj
+++ b/test/puppetlabs/http/client/async_ssl_config_test.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.http.client.async-ssl-config-test
   (:require [clojure.test :refer :all]
-            [clojure.java.io :refer [resource]] 
-            [puppetlabs.certificate-authority.core :as ssl]
+            [clojure.java.io :refer [resource]]
+            [puppetlabs.ssl-utils.core :as ssl]
             [puppetlabs.http.client.async :as http]
             [schema.test :as schema-test])
   (:import [javax.net.ssl SSLContext]))


### PR DESCRIPTION
This changes the usages to reflect the new name of the library and API.

This also contains upgrades for the clj-kitchensink and trapperkeeper to bring them up to the newest releases and in line with the versions used in puppet server.