### PR TITLE
(TK-145) fix application of default charset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 .lein-failures
+pom.xml

--- a/project.clj
+++ b/project.clj
@@ -34,7 +34,7 @@
                                   [puppetlabs/trapperkeeper ~tk-version]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]
-                                  [spyscope "0.1.4"]]
+                                  [spyscope "0.1.4" :exclusions [clj-time]]]
                    :injections [(require 'spyscope.core)]
                    ;; TK-143, enable SSLv3 for unit tests that exercise SSLv3
                    :jvm-opts ["-Djava.security.properties=./dev-resources/java.security"]}

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -12,9 +12,7 @@
 ;; these methods.
 
 (ns puppetlabs.http.client.async
-  (:import (com.puppetlabs.http.client HttpMethod HttpClientException
-                                       ClientOptions)
-           (org.apache.http.nio.client HttpAsyncClient)
+  (:import (com.puppetlabs.http.client HttpClientException ClientOptions)
            (org.apache.http.impl.nio.client HttpAsyncClients)
            (org.apache.http.client.methods HttpGet HttpHead HttpPost HttpPut HttpTrace HttpDelete HttpOptions HttpPatch)
            (org.apache.http.client.utils URIBuilder)
@@ -27,8 +25,7 @@
            (com.puppetlabs.http.client.impl Compression)
            (org.apache.http.client RedirectStrategy)
            (org.apache.http.impl.client LaxRedirectStrategy DefaultRedirectStrategy)
-           (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
-           (org.apache.http.conn.ssl SSLContexts))
+           (org.apache.http.nio.conn.ssl SSLIOSessionStrategy))
   (:require [puppetlabs.ssl-utils.core :as ssl]
             [clojure.string :as str]
             [puppetlabs.kitchensink.core :as ks]

--- a/test/com/puppetlabs/http/client/impl/java_client_test.clj
+++ b/test/com/puppetlabs/http/client/impl/java_client_test.clj
@@ -1,14 +1,14 @@
 (ns com.puppetlabs.http.client.impl.java-client-test
   (:import (com.puppetlabs.http.client.impl JavaClient)
            (org.apache.commons.io IOUtils)
-           (com.puppetlabs.http.client ResponseBodyType)
-           (org.apache.http.entity ContentType))
+           (com.puppetlabs.http.client ResponseBodyType RequestOptions)
+           (org.apache.http.entity ContentType)
+           (java.io ByteArrayInputStream))
   (:require [clojure.test :refer :all]))
 
 ;; NOTE: there are more comprehensive, end-to-end tests for
 ;; the Java client functionality lumped in with the clojure
-;; tests.  This namespace is just for some edge-casey,
-;; Java-only unit tests.
+;; tests.  This namespace is just for some Java-only unit tests.
 
 (deftest test-coerce-body-type
   (testing "Can handle a Content Type header with no charset"
@@ -18,3 +18,37 @@
                      body-stream
                      ResponseBodyType/TEXT
                      ContentType/WILDCARD))))))
+
+(defn request-options
+  [body content-type-value]
+  (new RequestOptions
+       nil {"content-type" content-type-value} body false nil))
+
+(defn compute-content-type
+  [body content-type-value]
+  (->
+    (JavaClient/getContentType body (request-options body content-type-value))
+    ;; Calling .toString on an instance of org.apache.http.entity.ContentType
+    ;; generates the string that'll actually end up in the header.
+    .toString))
+
+
+;; This test case is 100% copypasta from puppetlabs.http.client.async-test
+(deftest content-type-test
+  (testing "value of content-type header is computed correctly"
+    (testing "a byte stream which specifies application/octet-stream"
+      (let [body (ByteArrayInputStream. (byte-array [(byte 1) (byte 2)]))]
+        (is (= (compute-content-type body "application/octet-stream")
+               "application/octet-stream"))))
+
+    (testing "the request body is a string"
+      (testing "when a charset is specified, it is honored"
+        (let [body "foo"]
+          (is (= (compute-content-type body "text/plain; charset=US-ASCII")
+                 "text/plain; charset=US-ASCII"))))
+
+      (testing "a missing charset yields a content-type that maintains
+                the given mime-type but adds UTF-8 as the charset"
+        (let [body "foo"]
+          (is (= (compute-content-type body "text/html")
+                 "text/html; charset=UTF-8")))))))

--- a/test/puppetlabs/http/client/async_test.clj
+++ b/test/puppetlabs/http/client/async_test.clj
@@ -1,0 +1,31 @@
+(ns puppetlabs.http.client.async-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.http.client.async :refer :all])
+  (:import (java.io ByteArrayInputStream)))
+
+(defn compute-content-type
+  [body content-type-value]
+  (->
+    (content-type body {:headers {"content-type" content-type-value}})
+    ;; Calling .toString on an instance of org.apache.http.entity.ContentType
+    ;; generates the string that'll actually end up in the header.
+    .toString))
+
+(deftest content-type-test
+  (testing "value of content-type header is computed correctly"
+    (testing "a byte stream which specifies application/octet-stream"
+      (let [body (ByteArrayInputStream. (byte-array [(byte 1) (byte 2)]))]
+        (is (= (compute-content-type body "application/octet-stream")
+               "application/octet-stream"))))
+
+    (testing "the request body is a string"
+      (testing "when a charset is specified, it is honored"
+        (let [body "foo"]
+          (is (= (compute-content-type body "text/plain; charset=US-ASCII")
+                 "text/plain; charset=US-ASCII"))))
+
+      (testing "a missing charset yields a content-type that maintains
+                the given mime-type but adds UTF-8 as the charset"
+        (let [body "foo"]
+          (is (= (compute-content-type body "text/html")
+                 "text/html; charset=UTF-8")))))))


### PR DESCRIPTION
Fix a bug in which a default charset of UTF-8 would be added to the
Content-Type header for certain requests.  This change restricts that
behavior to cases in which the body is a string and there is no charset
provided by the caller.

@cprice404 @camlow325 If you two fine gentlemen would please review this, that'd be swell.