### PR TITLE
(TK-134) Add connect and socket timeout client configuration

### DIFF
--- a/doc/clojure-client.md
+++ b/doc/clojure-client.md
@@ -19,6 +19,15 @@ The following are the base set of options supported by the `create-client` funct
 * `:follow-redirects`: used to set whether or not the client should follow
   redirects in general. Defaults to true. If set to false, will override
   the :force-redirects setting.
+* `:connect-timeout-milliseconds`: maximum number of milliseconds that the
+  client will wait for a connection to be established.  A value of 0 is
+  interpreted as infinite.  A negative value for or the absence of this option
+  is interpreted as undefined (system default).
+* `:socket-timeout-milliseconds`: maximum number of milliseconds that the
+  client will allow for no data to be available on the socket before closing the
+  underlying connection, 'SO_TIMEOUT' in socket terms.  A timeout of zero is
+  interpreted as an infinite timeout.  A negative value for or the absence of
+  this setting is interpreted as undefined (system default).
 * `:ssl-protocols`: an array used to set the list of SSL protocols that the client
   could select from when talking to the server. Defaults to 'TLSv1',
   'TLSv1.1', and 'TLSv1.2'.

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,6 @@
 (def ks-version "1.0.0")
-(def tk-version "1.0.1")
+(def tk-version "1.1.0")
+(def tk-jetty-version "1.2.0")
 
 (defproject puppetlabs/http-client "0.4.3-SNAPSHOT"
   :description "HTTP client wrapper"
@@ -11,8 +12,8 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [puppetlabs/ssl-utils "0.7.0"]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [puppetlabs/ssl-utils "0.8.0"]
                  [org.clojure/tools.logging "0.2.6"]
                  [puppetlabs/kitchensink ~ks-version]
                  [org.slf4j/slf4j-api "1.7.6"]
@@ -33,7 +34,8 @@
   :profiles {:dev {:dependencies [[puppetlabs/kitchensink ~ks-version :classifier "test"]
                                   [puppetlabs/trapperkeeper ~tk-version]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 "0.9.0"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
                                   [spyscope "0.1.4" :exclusions [clj-time]]]
                    :injections [(require 'spyscope.core)]
                    ;; TK-143, enable SSLv3 for unit tests that exercise SSLv3

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -383,7 +383,7 @@
        redirects in general. Defaults to true. If set to false, will override
        the :force-redirects setting.
    * :connect-timeout-milliseconds - maximum number of milliseconds that the
-       client will wait for a connection to be established.  A value of 0 is
+       client will wait for a connection to be established.  A value of zero is
        interpreted as infinite.  A negative value for or the absence of this
        option is interpreted as undefined (system default).
    * :socket-timeout-milliseconds - maximum number of milliseconds that the

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -25,7 +25,8 @@
            (com.puppetlabs.http.client.impl Compression)
            (org.apache.http.client RedirectStrategy)
            (org.apache.http.impl.client LaxRedirectStrategy DefaultRedirectStrategy)
-           (org.apache.http.nio.conn.ssl SSLIOSessionStrategy))
+           (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
+           (org.apache.http.client.config RequestConfig))
   (:require [puppetlabs.ssl-utils.core :as ssl]
             [clojure.string :as str]
             [puppetlabs.kitchensink.core :as ks]
@@ -293,14 +294,36 @@
         :else
           (DefaultRedirectStrategy.))))
 
+(schema/defn request-config :- RequestConfig
+  [connect-timeout-milliseconds :- (schema/maybe schema/Int)
+   socket-timeout-milliseconds :- (schema/maybe schema/Int)]
+  (let [request-config-builder (RequestConfig/custom)]
+    (if connect-timeout-milliseconds
+      (.setConnectTimeout request-config-builder
+                          connect-timeout-milliseconds))
+    (if socket-timeout-milliseconds
+      (.setSocketTimeout request-config-builder
+                         socket-timeout-milliseconds))
+    (.build request-config-builder)))
+
 (schema/defn ^:always-validate create-default-client :- common/Client
   [opts :- common/ClientOptions]
   (let [ssl-ctxt-opts   (configure-ssl-ctxt (extract-ssl-opts opts))
         ssl-prot-opts   (select-keys opts [:ssl-protocols :cipher-suites])
         client-builder  (HttpAsyncClients/custom)
+        connect-timeout (:connect-timeout-milliseconds opts)
+        socket-timeout  (:socket-timeout-milliseconds opts)
         client          (do (when (:ssl-context ssl-ctxt-opts)
-                              (.setSSLStrategy client-builder (ssl-strategy ssl-ctxt-opts ssl-prot-opts)))
-                            (.setRedirectStrategy client-builder (redirect-strategy opts))
+                              (.setSSLStrategy client-builder
+                                               (ssl-strategy
+                                                 ssl-ctxt-opts ssl-prot-opts)))
+                            (.setRedirectStrategy client-builder
+                                                  (redirect-strategy opts))
+                            (if (or connect-timeout socket-timeout)
+                              (.setDefaultRequestConfig client-builder
+                                                        (request-config
+                                                          connect-timeout
+                                                          socket-timeout)))
                             (.build client-builder))]
     (.start client)
     client))
@@ -359,6 +382,16 @@
    * :follow-redirects - used to set whether or  not the client should follow
        redirects in general. Defaults to true. If set to false, will override
        the :force-redirects setting.
+   * :connect-timeout-milliseconds - maximum number of milliseconds that the
+       client will wait for a connection to be established.  A value of 0 is
+       interpreted as infinite.  A negative value for or the absence of this
+       option is interpreted as undefined (system default).
+   * :socket-timeout-milliseconds - maximum number of milliseconds that the
+       client will allow for no data to be available on the socket before
+       closing the underlying connection, 'SO_TIMEOUT' in socket terms.  A
+       timeout of zero is interpreted as an infinite timeout.  A negative value
+       for or the absence of this setting is interpreted as undefined (system
+       default).
    * :ssl-protocols - used to set the list of SSL protocols that the client
        could select from when talking to the server. Defaults to 'TLSv1',
        'TLSv1.1', and 'TLSv1.2'.

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -60,7 +60,9 @@
    (ok :ssl-protocols)    [schema/Str]
    (ok :cipher-suites) [schema/Str]
    (ok :force-redirects)  schema/Bool
-   (ok :follow-redirects) schema/Bool})
+   (ok :follow-redirects) schema/Bool
+   (ok :connect-timeout-milliseconds) schema/Int
+   (ok :socket-timeout-milliseconds) schema/Int})
 
 (def RawUserRequestOptions
   "The list of request options passed by a user into the
@@ -101,31 +103,33 @@
   (schema/either {} SslContextOptions SslCertOptions SslCaCertOptions))
 
 (def SslProtocolOptions
-  {(schema/optional-key :ssl-protocols) [schema/Str]
-   (schema/optional-key :cipher-suites) [schema/Str]})
+  {(ok :ssl-protocols) [schema/Str]
+   (ok :cipher-suites) [schema/Str]})
 
-(def RedirectOptions
-  {(schema/optional-key :force-redirects)  schema/Bool
-   (schema/optional-key :follow-redirects) schema/Bool})
+(def BaseClientOptions
+  {(ok :force-redirects)  schema/Bool
+   (ok :follow-redirects) schema/Bool
+   (ok :connect-timeout-milliseconds) schema/Int
+   (ok :socket-timeout-milliseconds) schema/Int})
 
 (def UserRequestOptions
   "A cleaned-up version of RawUserRequestClientOptions, which is formed after
   validating the RawUserRequestClientOptions and merging it with the defaults."
   (schema/either
-    (merge RequestOptions RedirectOptions)
-    (merge RequestOptions SslContextOptions SslProtocolOptions RedirectOptions)
-    (merge RequestOptions SslCaCertOptions SslProtocolOptions RedirectOptions)
-    (merge RequestOptions SslCertOptions SslProtocolOptions RedirectOptions)))
+    (merge RequestOptions BaseClientOptions)
+    (merge RequestOptions SslContextOptions SslProtocolOptions BaseClientOptions)
+    (merge RequestOptions SslCaCertOptions SslProtocolOptions BaseClientOptions)
+    (merge RequestOptions SslCertOptions SslProtocolOptions BaseClientOptions)))
 
 (def ClientOptions
   "The options from UserRequestOptions that are related to the
    instantiation/management of a client. This is everything
    from UserRequestOptions not included in RequestOptions."
   (schema/either
-    RedirectOptions
-    (merge SslContextOptions SslProtocolOptions RedirectOptions)
-    (merge SslCertOptions SslProtocolOptions RedirectOptions)
-    (merge SslCaCertOptions SslProtocolOptions RedirectOptions)))
+    BaseClientOptions
+    (merge SslContextOptions SslProtocolOptions BaseClientOptions)
+    (merge SslCertOptions SslProtocolOptions BaseClientOptions)
+    (merge SslCaCertOptions SslProtocolOptions BaseClientOptions)))
 
 (def ResponseCallbackFn
   (schema/maybe (schema/pred ifn?)))

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -16,7 +16,9 @@
   [opts :- common/RawUserRequestClientOptions]
   (select-keys opts [:ssl-context :ssl-ca-cert :ssl-cert :ssl-key
                      :ssl-protocols :cipher-suites
-                     :force-redirects :follow-redirects]))
+                     :force-redirects :follow-redirects
+                     :connect-timeout-milliseconds
+                     :socket-timeout-milliseconds]))
 
 (schema/defn extract-request-opts :- common/RawUserRequestOptions
   [opts :- common/RawUserRequestClientOptions]

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -46,7 +46,7 @@ public class ClientOptions {
      * @param connectTimeoutMilliseconds Maximum number of milliseconds that
      *                                     the client will wait for a
      *                                     connection to be established.  A
-     *                                     value of 0 is interpreted as
+     *                                     value of zero is interpreted as
      *                                     infinite.  A negative value is
      *                                     interpreted as undefined (system
      *                                     default).

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -22,6 +22,8 @@ public class ClientOptions {
     private boolean insecure = false;
     private boolean forceRedirects = false;
     private boolean followRedirects = true;
+    private int connectTimeoutMilliseconds = -1;
+    private int socketTimeoutMilliseconds = -1;
 
     /**
      * Constructor for the ClientOptions class. When this constructor is called,
@@ -41,6 +43,22 @@ public class ClientOptions {
      * @param insecure Whether or not the client should use an insecure connection.
      * @param forceRedirects Whether or not the client should follow redirects on POST or PUT requests.
      * @param followRedirects Whether or not the client should follow redirects in general.
+     * @param connectTimeoutMilliseconds Maximum number of milliseconds that
+     *                                     the client will wait for a
+     *                                     connection to be established.  A
+     *                                     value of 0 is interpreted as
+     *                                     infinite.  A negative value is
+     *                                     interpreted as undefined (system
+     *                                     default).
+     * @param socketTimeoutMilliseconds Maximum number of milliseconds that
+     *                                    the client will allow for no data to
+     *                                    be available on the socket before
+     *                                    closing the underlying connection,
+     *                                    <code>SO_TIMEOUT</code> in socket
+     *                                    terms.  A timeout of zero is
+     *                                    interpreted as an infinite timeout.
+     *                                    A negative value is interpreted as
+     *                                    undefined (system default).
      */
     public ClientOptions(SSLContext sslContext,
                          String sslCert,
@@ -50,7 +68,9 @@ public class ClientOptions {
                          String[] sslCipherSuites,
                          boolean insecure,
                          boolean forceRedirects,
-                         boolean followRedirects) {
+                         boolean followRedirects,
+                         int connectTimeoutMilliseconds,
+                         int socketTimeoutMilliseconds) {
         this.sslContext = sslContext;
         this.sslCert = sslCert;
         this.sslKey = sslKey;
@@ -60,6 +80,8 @@ public class ClientOptions {
         this.insecure = insecure;
         this.forceRedirects = forceRedirects;
         this.followRedirects = followRedirects;
+        this.connectTimeoutMilliseconds = connectTimeoutMilliseconds;
+        this.socketTimeoutMilliseconds = socketTimeoutMilliseconds;
     }
 
     public SSLContext getSslContext() {
@@ -127,6 +149,26 @@ public class ClientOptions {
     public boolean getFollowRedirects() { return followRedirects; }
     public ClientOptions setFollowRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
+        return this;
+    }
+
+    public int getConnectTimeoutMilliseconds() {
+        return connectTimeoutMilliseconds;
+    }
+
+    public ClientOptions setConnectTimeoutMilliseconds(
+            int connectTimeoutMilliseconds) {
+        this.connectTimeoutMilliseconds = connectTimeoutMilliseconds;
+        return this;
+    }
+
+    public int getSocketTimeoutMilliseconds() {
+        return socketTimeoutMilliseconds;
+    }
+
+    public ClientOptions setSocketTimeoutMilliseconds(
+            int socketTimeoutMilliseconds) {
+        this.socketTimeoutMilliseconds = socketTimeoutMilliseconds;
         return this;
     }
 }

--- a/src/java/com/puppetlabs/http/client/SimpleRequestOptions.java
+++ b/src/java/com/puppetlabs/http/client/SimpleRequestOptions.java
@@ -28,6 +28,9 @@ public class SimpleRequestOptions {
     private ResponseBodyType as = ResponseBodyType.STREAM;
     private boolean forceRedirects = false;
     private boolean followRedirects = true;
+    private int connectTimeoutMilliseconds = -1;
+    private int socketTimeoutMilliseconds = -1;
+
 
     /**
      * Constructor for SimpleRequestOptions. When this constructor is used,
@@ -151,6 +154,26 @@ public class SimpleRequestOptions {
     public boolean getFollowRedirects() { return followRedirects; }
     public SimpleRequestOptions setFollowRedirects(boolean followRedirects) {
         this.followRedirects = followRedirects;
+        return this;
+    }
+
+    public int getConnectTimeoutMilliseconds() {
+        return connectTimeoutMilliseconds;
+    }
+
+    public SimpleRequestOptions setConnectTimeoutMilliseconds(
+            int connectTimeoutMilliseconds) {
+        this.connectTimeoutMilliseconds = connectTimeoutMilliseconds;
+        return this;
+    }
+
+    public int getSocketTimeoutMilliseconds() {
+        return socketTimeoutMilliseconds;
+    }
+
+    public SimpleRequestOptions setSocketTimeoutMilliseconds(
+            int socketTimeoutMilliseconds) {
+        this.socketTimeoutMilliseconds = socketTimeoutMilliseconds;
         return this;
     }
 }

--- a/src/java/com/puppetlabs/http/client/Sync.java
+++ b/src/java/com/puppetlabs/http/client/Sync.java
@@ -45,10 +45,15 @@ public class Sync {
         boolean insecure = simpleOptions.getInsecure();
         boolean forceRedirects = simpleOptions.getForceRedirects();
         boolean followRedirects = simpleOptions.getFollowRedirects();
+        int connectTimeoutMilliseconds =
+                simpleOptions.getConnectTimeoutMilliseconds();
+        int socketTimeoutMilliseconds =
+                simpleOptions.getSocketTimeoutMilliseconds();
 
         return new ClientOptions(sslContext, sslCert, sslKey, sslCaCert,
                 sslProtocols, sslCipherSuites, insecure,
-                forceRedirects, followRedirects);
+                forceRedirects, followRedirects, connectTimeoutMilliseconds,
+                socketTimeoutMilliseconds);
     }
 
     private static Response request(SimpleRequestOptions simpleRequestOptions,

--- a/src/java/com/puppetlabs/http/client/impl/CoercedClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/impl/CoercedClientOptions.java
@@ -8,17 +8,23 @@ public class CoercedClientOptions {
     private final String[] sslCipherSuites;
     private final boolean forceRedirects;
     private final boolean followRedirects;
+    private final int connectTimeoutMilliseconds;
+    private final int socketTimeoutMilliseconds;
 
     public CoercedClientOptions(SSLContext sslContext,
                                 String[] sslProtocols,
                                 String[] sslCipherSuites,
                                 boolean forceRedirects,
-                                boolean followRedirects) {
+                                boolean followRedirects,
+                                int connectTimeoutMilliseconds,
+                                int socketTimeoutMilliseconds) {
         this.sslContext = sslContext;
         this.sslProtocols = sslProtocols;
         this.sslCipherSuites = sslCipherSuites;
         this.forceRedirects = forceRedirects;
         this.followRedirects = followRedirects;
+        this.connectTimeoutMilliseconds = connectTimeoutMilliseconds;
+        this.socketTimeoutMilliseconds = socketTimeoutMilliseconds;
     }
 
     public SSLContext getSslContext() { return sslContext; }
@@ -30,4 +36,12 @@ public class CoercedClientOptions {
     public boolean getForceRedirects() { return forceRedirects; }
 
     public boolean getFollowRedirects() { return followRedirects; }
+
+    public int getConnectTimeoutMilliseconds() {
+        return connectTimeoutMilliseconds;
+    }
+
+    public int getSocketTimeoutMilliseconds() {
+        return socketTimeoutMilliseconds;
+    }
 }

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -256,10 +256,10 @@
                            (Async/createClient))]
       (let [request-options     (RequestOptions. "http://127.0.0.255:65535")
             time-before-connect (System/currentTimeMillis)]
-        (is (instance? SocketTimeoutException (-> client
-                                                  (.get request-options)
-                                                  (.deref)
-                                                  (.getError)))
+        (is (connect-exception-thrown? (-> client
+                                           (.get request-options)
+                                           (.deref)
+                                           (.getError)))
             "Unexpected result for connection attempt")
         (is (elapsed-within-range? time-before-connect 2000)
             "Connection attempt took significantly longer than timeout")))))
@@ -270,9 +270,10 @@
     (with-open [client (async/create-client
                          {:connect-timeout-milliseconds 250})]
       (let [time-before-connect (System/currentTimeMillis)]
-        (is (instance? SocketTimeoutException
-                       (-> @(common/get client "http://127.0.0.255:65535")
-                           :error))
+        (is (connect-exception-thrown? (-> @(common/get
+                                              client
+                                              "http://127.0.0.255:65535")
+                                           :error))
             "Unexpected result for connection attempt")
         (is (elapsed-within-range? time-before-connect 2000)
             "Connection attempt took significantly longer than timeout")))))

--- a/test/puppetlabs/http/client/sync_plaintext_test.clj
+++ b/test/puppetlabs/http/client/sync_plaintext_test.clj
@@ -1,16 +1,16 @@
 (ns puppetlabs.http.client.sync-plaintext-test
   (:import (com.puppetlabs.http.client Sync RequestOptions SimpleRequestOptions
-                                       HttpClientException ResponseBodyType ClientOptions)
-           (javax.net.ssl SSLHandshakeException)
+                                       ResponseBodyType ClientOptions
+                                       HttpClientException)
            (java.io ByteArrayInputStream InputStream)
-           (java.nio.charset Charset)
            (org.apache.http.impl.nio.client HttpAsyncClients)
-           (java.net URI))
+           (java.net URI SocketTimeoutException ServerSocket))
   (:require [clojure.test :refer :all]
             [puppetlabs.http.client.test-common :refer :all]
             [puppetlabs.trapperkeeper.core :as tk]
             [puppetlabs.trapperkeeper.testutils.bootstrap :as testutils]
             [puppetlabs.trapperkeeper.testutils.logging :as testlogging]
+            [puppetlabs.trapperkeeper.testutils.webserver :as testwebserver]
             [puppetlabs.trapperkeeper.services.webserver.jetty9-service :as jetty9]
             [puppetlabs.http.client.sync :as sync]
             [puppetlabs.http.client.common :as common]
@@ -20,7 +20,7 @@
 (use-fixtures :once schema-test/validate-schemas)
 
 (defn app
-  [req]
+  [_]
   {:status 200
    :body "Hello, World!"})
 
@@ -510,3 +510,187 @@
               response (common/get client "http://localhost:8080/hello" {:as :text})]
           (is (= 302 (:status response)))
           (common/close client))))))
+
+(defmacro timeout-exception-thrown?
+  [& body]
+  `(try
+     (testlogging/with-test-logging ~@body)
+     (throw (IllegalStateException.
+              "Expected HttpClientException but none thrown!"))
+     (catch HttpClientException e#
+       (if-let [cause# (.getCause e#)]
+         (if (instance? SocketTimeoutException cause#)
+           true
+           (throw (IllegalStateException.
+                    (str
+                      "Expected SocketTimeoutException cause but found: "
+                      cause#))))
+         (throw (IllegalStateException.
+                  (str
+                    "Expected SocketTimeoutException but no cause found.  "
+                    "Message: " (.getMessage e#))))))))
+
+(deftest short-connect-timeout-nonpersistent-java-test-sync
+  (testing (str "connection times out properly for non-persistent java sync "
+                "request with short timeout")
+    (let [request-options     (-> "http://127.0.0.255:65535"
+                                  (SimpleRequestOptions.)
+                                  (.setConnectTimeoutMilliseconds 250))
+          time-before-connect (System/currentTimeMillis)]
+      (is (timeout-exception-thrown? (Sync/get request-options))
+          "Unexpected result for connection attempt")
+      (is (elapsed-within-range? time-before-connect 2000)
+          "Connection attempt took significantly longer than timeout"))))
+
+(deftest short-connect-timeout-persistent-java-test-sync
+  (testing (str "connection times out properly for java persistent client sync "
+                "request with short timeout")
+    (with-open [client (-> (ClientOptions.)
+                           (.setConnectTimeoutMilliseconds 250)
+                           (Sync/createClient))]
+      (let [request-options     (RequestOptions. "http://127.0.0.255:65535")
+            time-before-connect (System/currentTimeMillis)]
+        (is (timeout-exception-thrown? (.get client request-options))
+            "Unexpected result for connection attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Connection attempt took significantly longer than timeout")))))
+
+(deftest short-connect-timeout-nonpersistent-clojure-test-sync
+  (testing (str "connection times out properly for non-persistent clojure sync "
+                "request with short timeout")
+    (let [time-before-connect (System/currentTimeMillis)]
+      (is (thrown? SocketTimeoutException
+                   (sync/get "http://127.0.0.255:65535"
+                             {:connect-timeout-milliseconds 250}))
+          "Unexpected result for connection attempt")
+      (is (elapsed-within-range? time-before-connect 2000)
+          "Connection attempt took significantly longer than timeout"))))
+
+(deftest short-connect-timeout-persistent-clojure-test-sync
+  (testing (str "connection times out properly for clojure persistent client "
+                "sync request with short timeout")
+    (with-open [client (sync/create-client
+                         {:connect-timeout-milliseconds 250})]
+      (let [time-before-connect (System/currentTimeMillis)]
+        (is (thrown? SocketTimeoutException
+                     (common/get client "http://127.0.0.255:65535"))
+            "Unexpected result for connection attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Connection attempt took significantly longer than timeout")))))
+
+(deftest longer-connect-timeout-test-sync
+  (testing "connection succeeds for sync request with longer connect timeout"
+    (testlogging/with-test-logging
+      (testwebserver/with-test-webserver app port
+        (let [url (str "http://localhost:" port "/hello")]
+          (testing "java non-persistent sync client"
+            (let [request-options (.. (SimpleRequestOptions. url)
+                                      (setConnectTimeoutMilliseconds 2000))
+                  response        (Sync/get request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "java persistent sync client"
+            (with-open [client (-> (ClientOptions.)
+                                   (.setConnectTimeoutMilliseconds 2000)
+                                   (Sync/createClient))]
+              (let [response (.get client (RequestOptions. url))]
+                (is (= 200 (.getStatus response)))
+                (is (= "Hello, World!" (slurp (.getBody response)))))))
+          (testing "clojure non-persistent sync client"
+            (let [response (sync/get url
+                                     {:as :text
+                                      :connect-timeout-milliseconds 2000})]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (:body response)))))
+          (testing "clojure persistent sync client"
+            (with-open [client (sync/create-client
+                                 {:connect-timeout-milliseconds 2000})]
+              (let [response (common/get client url {:as :text})]
+                (is (= 200 (:status response)))
+                (is (= "Hello, World!" (:body response)))))))))))
+
+(deftest short-socket-timeout-nonpersistent-java-test-sync
+  (testing (str "socket read times out properly for non-persistent java sync "
+                "request with short timeout")
+    (with-open [server (ServerSocket. 0)]
+      (let [request-options     (-> "http://127.0.0.1:"
+                                    (str (.getLocalPort server))
+                                    (SimpleRequestOptions.)
+                                    (.setSocketTimeoutMilliseconds 250))
+            time-before-connect (System/currentTimeMillis)]
+        (is (timeout-exception-thrown? (Sync/get request-options))
+            "Unexpected result for get attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Get attempt took significantly longer than timeout")))))
+
+(deftest short-socket-timeout-persistent-java-test-sync
+  (testing (str "socket read times out properly for persistent java sync "
+                "request with short timeout")
+    (with-open [client (-> (ClientOptions.)
+                           (.setSocketTimeoutMilliseconds 250)
+                           (Sync/createClient))
+                server (ServerSocket. 0)]
+      (let [request-options     (-> "http://127.0.0.1:"
+                                    (str (.getLocalPort server))
+                                    (RequestOptions.))
+            time-before-connect (System/currentTimeMillis)]
+        (is (timeout-exception-thrown? (.get client request-options))
+            "Unexpected result for get attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Get attempt took significantly longer than timeout")))))
+
+(deftest short-socket-timeout-nonpersistent-clojure-test-sync
+  (testing (str "socket read times out properly for non-persistent clojure "
+                "sync request with short timeout")
+    (with-open [server (ServerSocket. 0)]
+      (let [url                 (str "http://127.0.0.1:" (.getLocalPort server))
+            time-before-connect (System/currentTimeMillis)]
+        (is (thrown? SocketTimeoutException
+                     (sync/get url {:socket-timeout-milliseconds 250}))
+            "Unexpected result for get attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Get attempt took significantly longer than timeout")))))
+
+(deftest short-connect-timeout-persistent-clojure-test-sync
+  (testing (str "socket read times out properly for clojure persistent client "
+                "sync request with short timeout")
+    (with-open [client (sync/create-client
+                         {:socket-timeout-milliseconds 250})
+                server (ServerSocket. 0)]
+      (let [url                 (str "http://127.0.0.1:" (.getLocalPort server))
+            time-before-connect (System/currentTimeMillis)]
+        (is (thrown? SocketTimeoutException (common/get client url))
+            "Unexpected result for get attempt")
+        (is (elapsed-within-range? time-before-connect 2000)
+            "Get attempt took significantly longer than timeout")))))
+
+(deftest longer-socket-timeout-test-sync
+  (testing "connection succeeds for sync request with longer socket timeout"
+    (testlogging/with-test-logging
+      (testwebserver/with-test-webserver app port
+        (let [url (str "http://localhost:" port "/hello")]
+          (testing "java non-persistent sync client"
+            (let [request-options (.. (SimpleRequestOptions. url)
+                                      (setSocketTimeoutMilliseconds 2000))
+                  response        (Sync/get request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "java persistent sync client"
+            (with-open [client (-> (ClientOptions.)
+                                   (.setSocketTimeoutMilliseconds 2000)
+                                   (Sync/createClient))]
+              (let [response (.get client (RequestOptions. url))]
+                (is (= 200 (.getStatus response)))
+                (is (= "Hello, World!" (slurp (.getBody response)))))))
+          (testing "clojure non-persistent sync client"
+            (let [response (sync/get url
+                                     {:as :text
+                                      :socket-timeout-milliseconds 2000})]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (:body response)))))
+          (testing "clojure persistent sync client"
+            (with-open [client (sync/create-client
+                                 {:socket-timeout-milliseconds 2000})]
+              (let [response (common/get client url {:as :text})]
+                (is (= 200 (:status response)))
+                (is (= "Hello, World!" (:body response)))))))))))

--- a/test/puppetlabs/http/client/test_common.clj
+++ b/test/puppetlabs/http/client/test_common.clj
@@ -1,6 +1,8 @@
 (ns puppetlabs.http.client.test-common
   (:require [ring.middleware.params :as ring-params]
-            [puppetlabs.trapperkeeper.core :as tk]))
+            [puppetlabs.trapperkeeper.core :as tk]
+            [puppetlabs.trapperkeeper.testutils.logging :as testlogging])
+  (:import (java.net ConnectException SocketTimeoutException)))
 
 (defn query-params-test
   [req]
@@ -38,6 +40,13 @@
   (init [this context]
         (add-ring-handler redirect-test-handler "/hello")
         context))
+
+(defmacro connect-exception-thrown?
+  [& body]
+  `(try
+     (testlogging/with-test-logging ~@body)
+     (catch SocketTimeoutException _# true)
+     (catch ConnectException _# true)))
 
 (defn elapsed-within-range?
   [start-time-milliseconds duration-milliseconds]

--- a/test/puppetlabs/http/client/test_common.clj
+++ b/test/puppetlabs/http/client/test_common.clj
@@ -38,3 +38,8 @@
   (init [this context]
         (add-ring-handler redirect-test-handler "/hello")
         context))
+
+(defn elapsed-within-range?
+  [start-time-milliseconds duration-milliseconds]
+  (<= (System/currentTimeMillis) (+ start-time-milliseconds
+                                    duration-milliseconds)))


### PR DESCRIPTION
This commit enables http clients to optionally configure a connect
and/or socket timeout for requests.  For persistent clients, the
timeout values can only be configured at the client and not a
per-request level.  Non-persistent client requests support the
configuration of these timeouts.

This commit also bumps a few dependencies - tk-jetty9 to 1.2.0,
trapperkeeper to 1.10, ssl-utils to 0.8.0, and clojure to 1.6.0 -
and adds the 'test' tk-jetty9 library as a dev dependency for
testing.