### PR TITLE
(TK-196) Update prismatic library dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -20,7 +20,8 @@
                  [org.apache.httpcomponents/httpasyncclient "4.0.2"]
                  [org.apache.httpcomponents/httpcore "4.3.2"]
                  [commons-io "2.1"]
-                 [prismatic/schema "0.2.2"]]
+                 [prismatic/schema "0.4.0"]
+                 [prismatic/plumbing "0.4.2"]]
 
   :source-paths ["src/clj"]
   :java-source-paths ["src/java"]
@@ -52,4 +53,4 @@
   :lein-release {:scm :git
                  :deploy-via :lein-deploy}
 
-  :plugins [[lein-release "1.0.5"]])
+  :plugins [[lein-release "1.0.5" :exclusions [org.clojure/clojure]]])

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -372,7 +372,7 @@
               (future-callback client result opts callback))
     result))
 
-(schema/defn create-client :- common/HTTPClient
+(schema/defn create-client :- (schema/protocol common/HTTPClient)
   "Creates a client to be used for making one or more HTTP requests.
 
    opts (base set):

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -39,7 +39,7 @@
   (with-open [client (async/create-default-client (extract-client-opts req))]
     (request-with-client (extract-request-opts req) client)))
 
-(schema/defn create-client :- common/HTTPClient
+(schema/defn create-client :- (schema/protocol common/HTTPClient)
   [opts :- common/ClientOptions]
   (let [client (async/create-default-client opts)]
     (reify common/HTTPClient
@@ -108,5 +108,3 @@
   error is returned."
   ([url] (patch url {}))
   ([url opts] (request (assoc opts :method :patch :url url))))
-
-


### PR DESCRIPTION
The prismatic/plumbing and prismatic/schema library dependencies are
lagging behind the latest stable version. This will increasingly
cause conflicts in trapperkeeper projects. This patch updates the
dependencies and fixes several functions which were validating against
schemas incompatible with the new versions.

* Update project.clj dependencies
* Use protocol schema instead of the protocol object directly