### PR TITLE
(PE-11976) Add option to return response early and stream body asynchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 .lein-failures
 pom.xml
+.nrepl-port

--- a/doc/clojure-client.md
+++ b/doc/clojure-client.md
@@ -83,9 +83,11 @@ which is a map containing options for the HTTP request. These options are as fol
   'gzip, deflate' will be added to the request, and the response will be
    automatically decompressed if it contains a recognized 'content-encoding'
    header.  Defaults to `true`.
-* `:as`: optional; used to control the data type of the response body.  Supported values
-  are `:text` and `:stream`, which will return a `String` or an
-  `InputStream`, respectively.  Defaults to `:stream`.
+* `:as`: optional; used to control the data type of the response body. Defaults to `:stream`. Supported values
+  are:
+ * `:text` which will return a `String` 
+ * `:stream` which will return an `InputStream`
+ * `:unbuffered-stream` which is a variant of `:stream` that will buffer as little data as possible
 * `:query-params`: optional; used to set the query parameters of an http request. This should be
   a map, where each key and each value is a String.
 

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -18,15 +18,17 @@
            (org.apache.http.client.utils URIBuilder)
            (org.apache.http.concurrent FutureCallback)
            (org.apache.http.message BasicHeader)
-           (org.apache.http Consts Header)
+           (org.apache.http Consts Header HttpRequest HttpResponse)
            (org.apache.http.nio.entity NStringEntity)
            (org.apache.http.entity InputStreamEntity ContentType)
            (java.io InputStream)
-           (com.puppetlabs.http.client.impl Compression)
+           (com.puppetlabs.http.client.impl Compression StreamingAsyncResponseConsumer FnDeliverable)
            (org.apache.http.client RedirectStrategy)
            (org.apache.http.impl.client LaxRedirectStrategy DefaultRedirectStrategy)
            (org.apache.http.nio.conn.ssl SSLIOSessionStrategy)
-           (org.apache.http.client.config RequestConfig))
+           (org.apache.http.client.config RequestConfig)
+           (org.apache.http.nio.client.methods HttpAsyncMethods)
+           (org.apache.http.nio.client HttpAsyncClient))
   (:require [puppetlabs.ssl-utils.core :as ssl]
             [clojure.string :as str]
             [puppetlabs.kitchensink.core :as ks]
@@ -239,22 +241,29 @@
    response :- common/Response]
   (deliver result (callback-response opts callback response)))
 
-(schema/defn future-callback
-  [client :- common/Client
-   result :- common/ResponsePromise
+(schema/defn complete-response
+  [result :- common/ResponsePromise
+   opts :- common/RequestOptions
+   callback :- common/ResponseCallbackFn
+   http-response :- HttpResponse]
+  (try
+    (let [response (cond-> (response-map opts http-response)
+                           (and (:decompress-body opts)
+                                (not= :unbuffered-stream (:as opts))) (decompress)
+                           (and (not= :stream (:as opts))
+                                (not= :unbuffered-stream (:as opts))) (coerce-body-type))]
+      (deliver-result result opts callback response))
+    (catch Exception e
+      (deliver-result result opts callback
+                      (error-response opts e)))))
+
+(schema/defn future-callback :- FutureCallback
+  [result :- common/ResponsePromise
    opts :- common/RequestOptions
    callback :- common/ResponseCallbackFn]
   (reify FutureCallback
     (completed [this http-response]
-      (try
-        (let [response (cond-> (response-map opts http-response)
-                               (:decompress-body opts) (decompress)
-                               (not= :stream (:as opts)) (coerce-body-type))]
-          (deliver-result result opts callback response))
-        (catch Exception e
-          (log/warn e "Error when delivering response")
-          (deliver-result result opts callback
-                          (error-response opts e)))))
+      (complete-response result opts callback http-response))
     (failed [this e]
       (deliver-result result opts callback
                       (error-response opts e)))
@@ -330,6 +339,39 @@
     (.start client)
     client))
 
+(schema/defn execute-with-consumer
+  [client :- HttpAsyncClient
+   request :- HttpRequest
+   future-callback :- FutureCallback
+   result :- common/ResponsePromise
+   opts :- common/RequestOptions
+   callback :- common/ResponseCallbackFn]
+  (let [;; Create an Apache AsyncResponseConsumer that will return the response to us as soon as it is 
+        ;; available then send the response body asynchronously
+        consumer (StreamingAsyncResponseConsumer.
+                  (FnDeliverable.
+                   (fn
+                     [http-response]
+                     (complete-response result opts callback http-response))))
+        ;; If an error occurs early in the request, the consumer may not get a chance to return the
+        ;; response using the FnDeliverable. This wrapper around the future-callback guarantees that
+        ;; happens. It also takes care of notifying the consumer of the final result.
+        streaming-complete-callback (reify
+                                      FutureCallback
+                                      (completed [this http-response]
+                                        (.setFinalResult consumer nil)
+                                        (.completed future-callback http-response))
+                                      (failed [this ex]
+                                        (.setFinalResult consumer ex)
+                                        (.failed future-callback ex))
+                                      (cancelled [this]
+                                        (.setFinalResult consumer nil)
+                                        (.cancelled future-callback)))]
+    (.execute client
+              (HttpAsyncMethods/create request)
+              consumer
+              streaming-complete-callback)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
@@ -358,7 +400,7 @@
    * :query-params - used to set the query parameters of an http request"
   [opts :- common/RawUserRequestOptions
    callback :- common/ResponseCallbackFn
-   client]
+   client :- HttpAsyncClient]
   (let [defaults {:headers         {}
                   :body            nil
                   :decompress-body true
@@ -370,8 +412,10 @@
     (.setHeaders request (:headers coerced-opts))
     (when body
       (.setEntity request body))
-    (.execute client request
-              (future-callback client result opts callback))
+    (let [future-callback (future-callback result opts callback)]
+      (if (= :unbuffered-stream (:as opts))
+        (execute-with-consumer client request future-callback result opts callback)
+        (.execute client request future-callback)))
     result))
 
 (schema/defn create-client :- (schema/protocol common/HTTPClient)

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -39,7 +39,7 @@
   (schema/maybe (schema/either String InputStream)))
 
 (def BodyType
-  (schema/enum :text :stream))
+  (schema/enum :text :stream :unbuffered-stream))
 
 (def RawUserRequestClientOptions
   "The list of Request and client options passed by a user into

--- a/src/java/com/puppetlabs/http/client/impl/Deliverable.java
+++ b/src/java/com/puppetlabs/http/client/impl/Deliverable.java
@@ -1,0 +1,5 @@
+package com.puppetlabs.http.client.impl;
+
+public interface Deliverable<T> {
+    void deliver(T t);
+}

--- a/src/java/com/puppetlabs/http/client/impl/ExceptionInsertingPipedInputStream.java
+++ b/src/java/com/puppetlabs/http/client/impl/ExceptionInsertingPipedInputStream.java
@@ -25,7 +25,7 @@ public class ExceptionInsertingPipedInputStream extends PipedInputStream {
     @Override
     public synchronized int read() throws IOException {
         int read = super.read();
-        if (read == 1) {
+        if (read == -1) {
             checkFinalResult();
         }
         return read;
@@ -38,6 +38,12 @@ public class ExceptionInsertingPipedInputStream extends PipedInputStream {
             checkFinalResult();
         }
         return read;
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        checkFinalResult();
     }
 
 }

--- a/src/java/com/puppetlabs/http/client/impl/ExceptionInsertingPipedInputStream.java
+++ b/src/java/com/puppetlabs/http/client/impl/ExceptionInsertingPipedInputStream.java
@@ -1,0 +1,43 @@
+package com.puppetlabs.http.client.impl;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+
+public class ExceptionInsertingPipedInputStream extends PipedInputStream {
+
+    private final Promise<IOException> ioExceptionPromise;
+
+    public ExceptionInsertingPipedInputStream(Promise<IOException> ioExceptionPromise) {
+        this.ioExceptionPromise = ioExceptionPromise;
+    }
+
+    private void checkFinalResult() throws IOException {
+        try {
+            IOException ioException = ioExceptionPromise.deref();
+            if (ioException != null) {
+                throw ioException;
+            }
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public synchronized int read() throws IOException {
+        int read = super.read();
+        if (read == 1) {
+            checkFinalResult();
+        }
+        return read;
+    }
+
+    @Override
+    public synchronized int read(byte[] b, int off, int len) throws IOException {
+        int read = super.read(b, off, len);
+        if (read == -1) {
+            checkFinalResult();
+        }
+        return read;
+    }
+
+}

--- a/src/java/com/puppetlabs/http/client/impl/FnDeliverable.java
+++ b/src/java/com/puppetlabs/http/client/impl/FnDeliverable.java
@@ -1,0 +1,17 @@
+package com.puppetlabs.http.client.impl;
+
+import clojure.lang.IFn;
+
+public class FnDeliverable<T> implements Deliverable<T> {
+
+    private final IFn fn;
+
+    public FnDeliverable(IFn fn) {
+        this.fn = fn;
+    }
+
+    @Override
+    public void deliver(T t) {
+        fn.invoke(t);
+    }
+}

--- a/src/java/com/puppetlabs/http/client/impl/Promise.java
+++ b/src/java/com/puppetlabs/http/client/impl/Promise.java
@@ -2,7 +2,7 @@ package com.puppetlabs.http.client.impl;
 
 import java.util.concurrent.CountDownLatch;
 
-public class Promise<T> {
+public class Promise<T> implements Deliverable<T> {
     private final CountDownLatch latch;
     private T value = null;
 

--- a/src/java/com/puppetlabs/http/client/impl/StreamingAsyncResponseConsumer.java
+++ b/src/java/com/puppetlabs/http/client/impl/StreamingAsyncResponseConsumer.java
@@ -47,6 +47,7 @@ public class StreamingAsyncResponseConsumer extends AsyncByteConsumer<HttpRespon
 
     @Override
     protected void releaseResources() {
+        super.releaseResources();
         this.response = null;
         this.promise = null;
         try {

--- a/src/java/com/puppetlabs/http/client/impl/StreamingAsyncResponseConsumer.java
+++ b/src/java/com/puppetlabs/http/client/impl/StreamingAsyncResponseConsumer.java
@@ -1,0 +1,88 @@
+package com.puppetlabs.http.client.impl;
+
+import org.apache.http.Header;
+import org.apache.http.HeaderElement;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.entity.DeflateDecompressingEntity;
+import org.apache.http.client.entity.GzipDecompressingEntity;
+import org.apache.http.entity.BasicHttpEntity;
+import org.apache.http.nio.IOControl;
+import org.apache.http.nio.client.methods.AsyncByteConsumer;
+import org.apache.http.protocol.HttpContext;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.nio.ByteBuffer;
+
+public class StreamingAsyncResponseConsumer extends AsyncByteConsumer<HttpResponse> {
+
+    private volatile HttpResponse response;
+    private volatile PipedOutputStream pos;
+    private volatile Deliverable<HttpResponse> promise;
+    private volatile Promise<IOException> ioExceptionPromise = new Promise<>();
+
+    public void setFinalResult(IOException ioException) {
+        ioExceptionPromise.deliver(ioException);
+    }
+
+    public StreamingAsyncResponseConsumer(Deliverable<HttpResponse> promise) {
+        this.promise = promise;
+    }
+
+    @Override
+    protected void onResponseReceived(final HttpResponse response) throws IOException {
+        PipedInputStream pis = new ExceptionInsertingPipedInputStream(ioExceptionPromise);
+        pos = new PipedOutputStream();
+        pos.connect(pis);
+        HttpEntity modifiedEntity = new BasicHttpEntity();
+        ((BasicHttpEntity) modifiedEntity).setContent(pis);
+        HttpEntity entity = response.getEntity();
+        if (entity != null) {
+            Header header = entity.getContentEncoding();
+            if (header != null) {
+                HeaderElement[] codecs = header.getElements();
+                for (HeaderElement codec : codecs) {
+                    if (codec.getName().equalsIgnoreCase("gzip")) {
+                        modifiedEntity = new GzipDecompressingEntity(modifiedEntity);
+                        break;
+                    } else if (codec.getName().equalsIgnoreCase("deflate")) {
+                        modifiedEntity = new DeflateDecompressingEntity(modifiedEntity);
+                        break;
+                    }
+                }
+            }
+        }
+        response.setEntity(modifiedEntity);
+        this.response = response;
+        promise.deliver(response);
+    }
+
+    @Override
+    protected void onByteReceived(final ByteBuffer buf, final IOControl ioctrl) throws IOException {
+        while (buf.hasRemaining()) {
+            byte[] bs = new byte[buf.remaining()];
+            buf.get(bs);
+            pos.write(bs);
+        }
+    }
+
+    @Override
+    protected void releaseResources() {
+        this.response = null;
+        this.promise = null;
+        try {
+            this.pos.close();
+            this.pos = null;
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    protected HttpResponse buildResult(final HttpContext context) {
+        return response;
+    }
+
+}

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -3,7 +3,8 @@
            (org.apache.http.impl.nio.client HttpAsyncClients)
            (java.net URI SocketTimeoutException ServerSocket ConnectException)
            (java.io PipedInputStream PipedOutputStream)
-           (java.util.concurrent TimeoutException))
+           (java.util.concurrent TimeoutException)
+           (java.util UUID))
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
             [puppetlabs.http.client.test-common :refer :all]
@@ -358,108 +359,162 @@
                 (is (= 200 (:status response)))
                 (is (= "Hello, World!" (:body response)))))))))))
 
-(defn- build-content-handler
-  [data initial-bytes-read? wait-forever?]
+(defn- generate-data
+  "Generate data of approximately the requested size, which is moderately compressible"
+  [data-size]
+  (apply str "xxxx" (repeatedly (/ data-size 35) #(UUID/randomUUID))))
+
+(defn- successful-handler
+  "A Ring handler that asynchronously sends some data, waits for confirmation the data has been received then sends
+  some more data"
+  [data send-more-data]
   (fn [_]
     (let [outstream (PipedOutputStream.)
-          instream (PipedInputStream. 4)]
+          instream (PipedInputStream.)]
       (.connect instream outstream)
       ;; Return the response immediately and asynchronously stream some data into it
       (future
        (.write outstream (.getBytes data))
-       (.flush outstream)
-       (if wait-forever?
-         ; The :socket-timeout-milliseconds setting on the client means we don't actually block forever and forces
-         ; a SocketTimeoutException on the underlying socket
-         (deref (promise)))
        ; Block until the client confirms it has read the first few bytes
-       ; Again :socket-timeout-milliseconds on the client ensures we can't really get stuck here, even if the
-       ; test fails
-       (if initial-bytes-read?
-         (deref initial-bytes-read?))
+       ; :socket-timeout-milliseconds on the client ensures we can't really get stuck here, even if the test fails
+       (if send-more-data (deref send-more-data))
        ; Write the last of the data
-       (.write outstream (.getBytes "xxxx"))
+       (.write outstream (.getBytes "yyyy"))
        (.close outstream))
       {:status 200
        :body instream})))
 
-(defn- clojure-streaming-success
-  [data-size opts]
-  (testing (str "clojure streaming success: " data-size " bytes with opts " opts)
-    (let [data (apply str (repeat (- data-size 4) "x"))
-          ;; If :unbuffered-stream is enabled then we check that we can read some bytes from the response before all
-          ;; bytes have actually been transmitted
-          ;; We need to make sure the amount of data sent is enough to ensure it doesn't get buffered by the OS or Jetty
-          ;; About 64K seems to be the threshold
-          initial-bytes-read? (if (and (= :unbuffered-stream (:as opts))
-                                       (not (:decompress-body opts))
-                                       (>= data-size (* 64 1024)))
-                                (promise))]
-      (testwebserver/with-test-webserver-and-config
-       (build-content-handler data initial-bytes-read? false) port {:shutdown-timeout-seconds 1}
-       (with-open [client (async/create-client {:connect-timeout-milliseconds 100 :socket-timeout-milliseconds 20000})]
-         (let [response @(common/get
-                          client
-                          (str "http://localhost:" port "/hello")
-                          opts)
-               {:keys [status body]} response]
-           (is (= 200 status))
-           (let [instream body
-                 buf (make-array Byte/TYPE 4)
-                 _ (.read instream buf)]
-             ;; Make sure we can read a few chars off of the stream
-             (is (= "xxxx" (String. buf "UTF-8")))
-             ;; Indicate we read some chars
-             (if initial-bytes-read? (deliver initial-bytes-read? true))
-             ;; Read the rest and validate the content
-             (let [final-string (str "xxxx" (slurp instream))]
-               (is (= (str data "xxxx") final-string))))))))))
+(defn- blocking-handler
+  "A Ring handler that sends some data but then never closes the socket"
+  [data]
+  (fn [_]
+    (let [outstream (PipedOutputStream.)
+          instream (PipedInputStream.)]
+      (.connect instream outstream)
+      ;; Return the response immediately and asynchronously stream some data into it
+      (future
+       (.write outstream (.getBytes data)))
+      {:status 200
+       :body instream})))
 
-(defn- clojure-streaming-socket-timeout
-  [data-size opts]
-  (testing (str "clojure streaming socket timeout: " data-size " bytes with opts " opts)
-    (let [data (apply str (repeat (- data-size 4) "x"))]
-      (try
-        (testwebserver/with-test-webserver-and-config
-         (build-content-handler data nil true) port {:shutdown-timeout-seconds 1}
-         (with-open [client (async/create-client {:connect-timeout-milliseconds 100 :socket-timeout-milliseconds 200})]
-           (let [response @(common/get
-                            client
-                            (str "http://localhost:" port "/hello")
-                            opts)
-                 {:keys [body error]} response]
-             (if (= :unbuffered-stream (:as opts))
-               (do
-                 (if error
-                   ;; If there's an error this should behave the same as :stream
-                   (is (instance? SocketTimeoutException error))
-                   ;; If there is no error, let's consume the body to get the exception
-                   (is (thrown? SocketTimeoutException (slurp body)))))
-               (do
-                 (is error)
-                 (is (instance? SocketTimeoutException error)))))))
-        (catch TimeoutException e
-          ;; Expected whenever a server-side failure is generated
-          )))))
+(defn- clojure-non-blocking-streaming
+  "Stream 32M of data (roughly) which is large enough to ensure the client won't buffer it all. Checks the data is
+  streamed in a non-blocking manner i.e some data is received by the client before the server has finished
+  transmission"
+  [decompress-body?]
+  (testlogging/with-test-logging
+   (let [data (generate-data (* 32 1024 1024))
+         opts {:as :unbuffered-stream :decompress-body decompress-body?}]
 
-(defn- clojure-streaming-connection-error
-  [opts]
-  (testing (str "clojure streaming connect error")
-    (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
-      (let [response @(common/get
-                       client
-                       (str "http://localhost:" 12345 "/hello")
-                       opts)
-            {:keys [error]} response]
-        (is error)
-        (is (instance? ConnectException error))))))
+     (testing " - check data can be streamed successfully success"
+       (let [send-more-data (promise)]
+         (testwebserver/with-test-webserver-and-config
+          (successful-handler data send-more-data) port {:shutdown-timeout-seconds 1}
+          (with-open [client (async/create-client {:connect-timeout-milliseconds 100
+                                                   :socket-timeout-milliseconds 20000})]
+            (let [response @(common/get client (str "http://localhost:" port "/hello") opts)
+                  {:keys [status body]} response]
+              (is (= 200 status))
+              (let [instream body
+                    buf (make-array Byte/TYPE 4)
+                    _ (.read instream buf)]
+                (is (= "xxxx" (String. buf "UTF-8")))       ;; Make sure we can read a few chars off of the stream
+                (deliver send-more-data true)               ;; Indicate we read some chars
+                (is (= (str data "yyyy") (str "xxxx" (slurp instream)))))))))) ;; Read the rest and validate
 
-(deftest clojure-streaming
-  (testing "clojure streaming is consistent with different payload sizes and opts"
-    (testlogging/with-test-logging
-     (doseq [data-size [32 (* 1024) (* 1024 1024)]
-             decompress-body? [false true]
-             as [:unbuffered-stream :stream]]
-       (clojure-streaming-success data-size {:as as :decompress-body decompress-body?})
-       (clojure-streaming-socket-timeout data-size {:as as :decompress-body decompress-body?})
-       (clojure-streaming-connection-error {:as as :decompress-body decompress-body?})))))
+     (testing " - check socket timeout is handled"
+       (try
+         (testwebserver/with-test-webserver-and-config
+          (blocking-handler data) port {:shutdown-timeout-seconds 1}
+          (with-open [client (async/create-client {:connect-timeout-milliseconds 100
+                                                   :socket-timeout-milliseconds 200})]
+            (let [response @(common/get client (str "http://localhost:" port "/hello") opts)
+                  {:keys [body error]} response]
+              (is (nil? error))
+              ;; Consume the body to get the exception
+              (is (thrown? SocketTimeoutException (slurp body))))))
+         (catch TimeoutException e
+           ;; Expected whenever a server-side failure is generated
+           )))
+
+     (testing " - check connection timeout is handled"
+       (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
+         (let [response @(common/get client (str "http://localhost:" 12345 "/bad") opts)
+               {:keys [error]} response]
+           (is error)
+           (is (instance? ConnectException error))))))))
+
+(deftest clojure-non-blocking-streaming-without-decompression
+  (testing "clojure :unbuffered-stream with 32MB payload and no decompression"
+    (clojure-non-blocking-streaming false)))
+
+(deftest clojure-non-blocking-streaming-with-decompression
+  (testing "clojure :unbuffered-stream with 32MB payload and decompression"
+    (clojure-non-blocking-streaming true)))
+
+(defn- clojure-blocking-streaming
+  "Stream data that is buffered client-side i.e. in a blocking manner"
+  [data opts]
+  (testlogging/with-test-logging
+
+   (testing " - check data can be streamed successfully success"
+     (testwebserver/with-test-webserver-and-config
+      (successful-handler data nil) port {:shutdown-timeout-seconds 1}
+      (with-open [client (async/create-client {:connect-timeout-milliseconds 100
+                                               :socket-timeout-milliseconds 20000})]
+        (let [response @(common/get client (str "http://localhost:" port "/hello") opts)
+              {:keys [status body]} response]
+          (is (= 200 status))
+          (let [instream body
+                buf (make-array Byte/TYPE 4)
+                _ (.read instream buf)]
+            (is (= "xxxx" (String. buf "UTF-8")))           ;; Make sure we can read a few chars off of the stream
+            (is (= (str data "yyyy") (str "xxxx" (slurp instream))))))))) ;; Read the rest and validate
+
+   (testing " - check socket timeout is handled"
+     (try
+       (testwebserver/with-test-webserver-and-config
+        (blocking-handler data) port {:shutdown-timeout-seconds 1}
+        (with-open [client (async/create-client {:connect-timeout-milliseconds 100
+                                                 :socket-timeout-milliseconds 200})]
+          (let [response @(common/get client (str "http://localhost:" port "/hello") opts)
+                {:keys [error]} response]
+            (is (instance? SocketTimeoutException error)))))
+       (catch TimeoutException e
+         ;; Expected whenever a server-side failure is generated
+         )))
+
+   (testing " - check connection timeout is handled"
+     (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
+       (let [response @(common/get client (str "http://localhost:" 12345 "/bad") opts)
+             {:keys [error]} response]
+         (is error)
+         (is (instance? ConnectException error)))))))
+
+(deftest clojure-blocking-streaming-without-decompression
+  (testing "clojure :unbuffered-stream with 1K payload and no decompression"
+    ;; This is a small enough payload that :unbuffered-stream still buffered it all in memory and so it behaves
+    ;; identically to :stream
+    (clojure-blocking-streaming (generate-data 1024) {:as :unbuffered-stream :decompress-body false})))
+
+(deftest clojure-blocking-streaming-with-decompression
+  (testing "clojure :unbuffered-stream with 1K payload and decompression"
+    ;; This is a small enough payload that :unbuffered-stream still buffered it all in memory and so it behaves
+    ;; identically to :stream
+    (clojure-blocking-streaming (generate-data 1024) {:as :unbuffered-stream :decompress-body true})))
+
+(deftest clojure-existing-streaming-with-small-payload-without-decompression
+  (testing "clojure :stream with 1K payload and no decompression"
+    (clojure-blocking-streaming (generate-data 1024) {:as :stream :decompress-body false})))
+
+(deftest clojure-existing-streaming-with-small-payload-with-decompression
+  (testing "clojure :stream with 1K payload and decompression"
+    (clojure-blocking-streaming (generate-data 1024) {:as :stream :decompress-body true})))
+
+(deftest clojure-existing-streaming-with-large-payload-without-decompression
+  (testing "clojure :stream with 32M payload and no decompression"
+    (clojure-blocking-streaming (generate-data (* 32 1024 1024)) {:as :stream :decompress-body false})))
+
+(deftest clojure-existing-streaming-with-large-payload-with-decompression
+  (testing "clojure :stream with 32M payload and decompression"
+    (clojure-blocking-streaming (generate-data (* 32 1024 1024)) {:as :stream :decompress-body true})))

--- a/test/puppetlabs/http/client/decompress_test.clj
+++ b/test/puppetlabs/http/client/decompress_test.clj
@@ -31,12 +31,6 @@
       (DeflaterInputStream.)))
 
 (deftest gzip-compress-test
-  (testing "clojure gzip decompression"
-    (let [test-response {:headers {"content-encoding" "gzip"}
-                         :body    (gzip compressible-body)}
-          response (async/decompress test-response)]
-      (is (not (contains? (:headers response) "content-encoding")))
-      (is (= compressible-body (slurp (:body response))))))
   (testing "java gzip decompression"
     (let [headers (HashMap. {"content-encoding" "gzip"})
           response (JavaClient/decompress (gzip compressible-body) headers)]
@@ -44,12 +38,6 @@
       (is (= compressible-body (slurp response))))))
 
 (deftest deflate-compress-test
-  (testing "clojure deflate decompression"
-    (let [test-response {:headers {"content-encoding" "deflate"}
-                         :body    (deflate compressible-body)}
-          response (async/decompress test-response)]
-      (is (not (contains? (:headers response) "content-encoding")))
-      (is (= compressible-body (slurp (:body response))))))
   (testing "java gzip decompression"
     (let [headers (HashMap. {"content-encoding" "deflate"})
           response (JavaClient/decompress (deflate compressible-body) headers)]


### PR DESCRIPTION
Adds a new :as option that uses Apache's AsyncConsumer to return the response as quickly as possible then asynchronously stream the response body using piped input/output streams.

This is Clojure support only at the moment.

@cprice404 @rlinehan Hopefully this aligns reasonably with our discussions.

@mruzicka @dmcpl If you guys have time, I'd appreciate your comments.

Thanks!