### PR TITLE
(maint) Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 target
-.lein-failures
 pom.xml
 .nrepl-port
+/.lein*


### PR DESCRIPTION
Update .gitignore to exclude anything that starts with `.lein` (e.g.
`.lein-failures` or `.lein-repl-history`).