### PR TITLE
(TK-308) Bump Apache HttpAsyncClient library to 4.1.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,7 @@
 
   :dependencies [[org.clojure/clojure "1.7.0"]
 
-                 [org.apache.httpcomponents/httpasyncclient "4.1.1"]
+                 [org.apache.httpcomponents/httpasyncclient "4.1.2"]
                  [org.apache.commons/commons-lang3 "3.4"]
                  [prismatic/schema "1.0.4"]
                  [org.slf4j/slf4j-api "1.7.13"]


### PR DESCRIPTION
There was a bug in the previous version of the Apache HttpAsyncClient library
that caused the cline tto hang if the process had exhausted the number of open
file descriptors it was allowed. This bug was fixed in the 4.1.2 release,
which this commit bumps to.