### PR TITLE
(TK-402) Allow metric namespace to be configurable

### DIFF
--- a/doc/clojure-client.md
+++ b/doc/clojure-client.md
@@ -42,7 +42,9 @@ The following are the base set of options supported by the `create-client` funct
   from. If specified, used in the namespace for metrics:
   `puppetlabs.<server-id>.http-client.experimental`.
 * `:metric-prefix`: a string for the prefix for metrics. If specified, metric
-  namespace is `<metric-prefix>.http-client.experimental`.
+  namespace is `<metric-prefix>.http-client.experimental`. If both
+  `metric-prefix` and `server-id` are specified, `metric-prefix` takes
+  precendence.
 
 ### SSL Options
 

--- a/doc/clojure-client.md
+++ b/doc/clojure-client.md
@@ -38,6 +38,11 @@ The following are the base set of options supported by the `create-client` funct
   to. If provided, metrics will automatically be registered for all requests
   made by the client. See the [metrics documentation](./metrics.md) for more
   info.
+* `:server-id`: a string for the name of the server the request is being made
+  from. If specified, used in the namespace for metrics:
+  `puppetlabs.<server-id>.http-client.experimental`.
+* `:metric-prefix`: a string for the prefix for metrics. If specified, metric
+  namespace is `<metric-prefix>.http-client.experimental`.
 
 ### SSL Options
 

--- a/doc/metrics.md
+++ b/doc/metrics.md
@@ -10,7 +10,7 @@ change.
 For using metrics with either the Java client or the Clojure client you must
 already have created a Dropwizard `MetricRegistry`.
 
-- [Metrics prefix](#metrics-prefix)
+- [Metric namespace](#metric-namespace)
 - [Types of metrics](#types-of-metrics)
 - [Getting back metrics](#getting-back-metrics)
 - [Clojure API](#clojure-api)
@@ -29,9 +29,26 @@ already have created a Dropwizard `MetricRegistry`.
     - [Filtering by metric-id](#filtering-by-metric-id-1)
 
 
-## Metrics prefix
+## Metric namespace
 
-All http metrics are prefixed with `puppetlabs.http-client.experimental`.
+By default, http metrics are prefixed with the namespace
+`puppetlabs.http-client.experimental`. This namespace can be customized with two
+client options, `server-id` and `metric-prefix`.
+
+When `server-id` is set, the metric namespace becomes
+`puppetlabs.<server-id>.http-client.experimental`.
+
+When `metric-prefix` is set, the metric namespace becomes
+`<metric-prefix>.http-client.experimental`.
+
+If both `server-id` and `metric-prefix` are set, `metric-prefix` wins out and
+a warning message is logged.
+
+For a Clojure client, the `get-client-metric-namespace` protocol method can
+be used to get back the metric namespace set for the client.
+
+For a Java client, the `getMetricNamespace` method can be used to get back the
+configured metric namespace.
 
 ## Types of metrics
 

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(def ks-version "1.2.0")
-(def tk-version "1.1.1")
+(def ks-version "1.3.0")
+(def tk-version "1.5.1")
 (def tk-jetty-version "1.5.0")
 
 (defproject puppetlabs/http-client "0.5.1-SNAPSHOT"
@@ -17,7 +17,7 @@
                  [org.apache.httpcomponents/httpasyncclient "4.1.2"]
                  [org.apache.commons/commons-lang3 "3.4"]
                  [prismatic/schema "1.0.4"]
-                 [org.slf4j/slf4j-api "1.7.13"]
+                 [org.slf4j/slf4j-api "1.7.20"]
                  [commons-io "2.4"]
                  [io.dropwizard.metrics/metrics-core "3.1.2"]
 

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -23,7 +23,8 @@
   (patch [this url] [this url opts])
   (make-request [this url method] [this url method opts])
   (close [this])
-  (get-client-metric-registry [this]))
+  (get-client-metric-registry [this])
+  (get-client-metric-namespace [this]))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -113,7 +114,9 @@
    (ok :follow-redirects) schema/Bool
    (ok :connect-timeout-milliseconds) schema/Int
    (ok :socket-timeout-milliseconds) schema/Int
-   (ok :metric-registry) MetricRegistry})
+   (ok :metric-registry) MetricRegistry
+   (ok :server-id) schema/Str
+   (ok :metric-prefix) schema/Str})
 
 (def UserRequestOptions
   "A cleaned-up version of RawUserRequestClientOptions, which is formed after

--- a/src/clj/puppetlabs/http/client/metrics.clj
+++ b/src/clj/puppetlabs/http/client/metrics.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as schema]
             [puppetlabs.http.client.common :as common])
   (:import (com.puppetlabs.http.client.metrics Metrics$MetricType Metrics
-                                            ClientMetricData)
+                                               ClientMetricData)
            (com.codahale.metrics MetricRegistry)))
 
 (schema/defn get-base-metric-data :- common/BaseMetricData
@@ -32,6 +32,10 @@
 (defn uppercase-method
   [method]
   (clojure.string/upper-case (name method)))
+
+(defn build-metric-namespace
+  [metric-prefix server-id]
+  (Metrics/buildMetricNamespace metric-prefix server-id))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public

--- a/src/java/com/puppetlabs/http/client/Async.java
+++ b/src/java/com/puppetlabs/http/client/Async.java
@@ -1,10 +1,8 @@
 package com.puppetlabs.http.client;
 
-import com.puppetlabs.http.client.impl.SslUtils;
 import com.puppetlabs.http.client.impl.JavaClient;
 import com.puppetlabs.http.client.impl.PersistentAsyncHttpClient;
-import com.puppetlabs.http.client.impl.CoercedClientOptions;
-import com.codahale.metrics.MetricRegistry;
+import com.puppetlabs.http.client.metrics.Metrics;
 
 /**
  * This class allows you to create an AsyncHttpClient for use in making
@@ -21,7 +19,9 @@ public class Async {
      * @return an AsyncHttpClient that can be used to make requests
      */
     public static AsyncHttpClient createClient(ClientOptions clientOptions) {
+        final String metricNamespace = Metrics.buildMetricNamespace(clientOptions.getMetricPrefix(),
+                clientOptions.getServerId());
         return new PersistentAsyncHttpClient(JavaClient.createClient(clientOptions),
-                clientOptions.getMetricRegistry());
+                clientOptions.getMetricRegistry(),metricNamespace);
     }
 }

--- a/src/java/com/puppetlabs/http/client/AsyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/AsyncHttpClient.java
@@ -20,6 +20,11 @@ public interface AsyncHttpClient extends Closeable{
     public MetricRegistry getMetricRegistry();
 
     /**
+     * @return the String metricNamespace for this Client
+     */
+    public String getMetricNamespace();
+
+    /**
      * Performs a GET request
      * @param url the URL against which to make the GET request
      * @return a Promise with the contents of the response

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -27,6 +27,8 @@ public class ClientOptions {
     private int connectTimeoutMilliseconds = -1;
     private int socketTimeoutMilliseconds = -1;
     private MetricRegistry metricRegistry;
+    private String metricPrefix;
+    private String serverId;
 
     /**
      * Constructor for the ClientOptions class. When this constructor is called,
@@ -181,6 +183,24 @@ public class ClientOptions {
 
     public ClientOptions setMetricRegistry(MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
+        return this;
+    }
+
+    public String getMetricPrefix() {
+        return metricPrefix;
+    }
+
+    public ClientOptions setMetricPrefix(String metricPrefix) {
+        this.metricPrefix = metricPrefix;
+        return this;
+    }
+
+    public String getServerId() {
+        return serverId;
+    }
+
+    public ClientOptions setServerId(String serverId) {
+        this.serverId = serverId;
         return this;
     }
 }

--- a/src/java/com/puppetlabs/http/client/Sync.java
+++ b/src/java/com/puppetlabs/http/client/Sync.java
@@ -2,6 +2,7 @@ package com.puppetlabs.http.client;
 
 import com.puppetlabs.http.client.impl.JavaClient;
 import com.puppetlabs.http.client.impl.PersistentSyncHttpClient;
+import com.puppetlabs.http.client.metrics.Metrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,8 +85,10 @@ public class Sync {
      * @return A persistent synchronous HTTP client
      */
     public static SyncHttpClient createClient(ClientOptions clientOptions) {
+        final String metricNamespace = Metrics.buildMetricNamespace(clientOptions.getMetricPrefix(),
+                clientOptions.getServerId());
         return new PersistentSyncHttpClient(JavaClient.createClient(clientOptions),
-                clientOptions.getMetricRegistry());
+                clientOptions.getMetricRegistry(), metricNamespace);
     }
 
     /**

--- a/src/java/com/puppetlabs/http/client/SyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/SyncHttpClient.java
@@ -19,6 +19,11 @@ public interface SyncHttpClient extends Closeable {
     public MetricRegistry getMetricRegistry();
 
     /**
+     * @return the String metricNamespace for this Client
+     */
+    public String getMetricNamespace();
+
+    /**
      * Makes a configurable HTTP request
      * @param requestOptions the options to configure the request
      * @param method the type of the HTTP request

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -263,7 +263,8 @@ public class JavaClient {
                                             final FutureCallback<HttpResponse> futureCallback,
                                             final HttpRequestBase request,
                                             final MetricRegistry metricRegistry,
-                                            final String[] metricId) {
+                                            final String[] metricId,
+                                            final String metricNamespace) {
 
         /*
          * Create an Apache AsyncResponseConsumer that will return the response to us as soon as it is available,
@@ -315,7 +316,7 @@ public class JavaClient {
 
         TimedFutureCallback<HttpResponse> timedStreamingCompleteCallback =
                 new TimedFutureCallback<>(streamingCompleteCallback,
-                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId));
+                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId, metricNamespace));
         client.execute(HttpAsyncMethods.create(request), consumer, timedStreamingCompleteCallback);
     }
 
@@ -324,7 +325,8 @@ public class JavaClient {
                                          final IResponseCallback callback,
                                          final CloseableHttpAsyncClient client,
                                          final ResponseDeliveryDelegate responseDeliveryDelegate,
-                                         final MetricRegistry registry) {
+                                         final MetricRegistry registry,
+                                         final String metricNamespace) {
 
         final CoercedRequestOptions coercedRequestOptions = coerceRequestOptions(requestOptions, method);
 
@@ -355,11 +357,11 @@ public class JavaClient {
 
         final String[] metricId = requestOptions.getMetricId();
         if (requestOptions.getAs() == ResponseBodyType.UNBUFFERED_STREAM) {
-            executeWithConsumer(client, futureCallback, request, registry, metricId);
+            executeWithConsumer(client, futureCallback, request, registry, metricId, metricNamespace);
         } else {
             TimedFutureCallback<HttpResponse> timedFutureCallback =
                     new TimedFutureCallback<>(futureCallback,
-                            TimerUtils.startFullResponseTimers(registry, request, metricId));
+                            TimerUtils.startFullResponseTimers(registry, request, metricId, metricNamespace));
             client.execute(request, timedFutureCallback);
         }
     }

--- a/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
@@ -14,11 +14,14 @@ import java.net.URISyntaxException;
 public class PersistentAsyncHttpClient implements AsyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
+    private String metricNamespace;
 
     public PersistentAsyncHttpClient(CloseableHttpAsyncClient client,
-                                     MetricRegistry metricRegistry) {
+                                     MetricRegistry metricRegistry,
+                                     String metricNamespace) {
         this.client = client;
         this.metricRegistry = metricRegistry;
+        this.metricNamespace = metricNamespace;
     }
 
     public void close() throws IOException {
@@ -29,11 +32,15 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
         return metricRegistry;
     }
 
+    public String getMetricNamespace() {
+        return metricNamespace;
+    }
+
     private Promise<Response> request(RequestOptions requestOptions, HttpMethod method) {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null,
-                client, responseDelivery, metricRegistry);
+                client, responseDelivery, metricRegistry, metricNamespace);
         return promise;
     }
 

--- a/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
@@ -17,12 +17,15 @@ import java.net.URISyntaxException;
 public class PersistentSyncHttpClient implements SyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
+    private String metricNamespace;
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistentSyncHttpClient.class);
 
     public PersistentSyncHttpClient(CloseableHttpAsyncClient client,
-                                    MetricRegistry metricRegistry) {
+                                    MetricRegistry metricRegistry,
+                                    String metricNamespace) {
         this.client = client;
         this.metricRegistry = metricRegistry;
+        this.metricNamespace = metricNamespace;
     }
 
     private static void logAndRethrow(String msg, Throwable t) {
@@ -34,11 +37,15 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
         return metricRegistry;
     }
 
+    public String getMetricNamespace() {
+        return metricNamespace;
+    }
+
     public Response request(RequestOptions requestOptions, HttpMethod method) {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null, client,
-                responseDelivery, metricRegistry);
+                responseDelivery, metricRegistry, metricNamespace);
         Response response = null;
         try {
             response = promise.deref();

--- a/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
@@ -41,7 +41,8 @@ public class TimerUtils {
     }
 
     private static ArrayList<Timer.Context> startFullResponseMetricIdTimers(MetricRegistry registry,
-                                                                            String[] metricId) {
+                                                                            String[] metricId,
+                                                                            String metricPrefix) {
         ArrayList<Timer.Context> timerContexts = new ArrayList<>();
         for (int i = 0; i < metricId.length; i++) {
             ArrayList<String> currentId = new ArrayList<>();
@@ -52,7 +53,7 @@ public class TimerUtils {
             currentIdWithNamespace.add(Metrics.NAMESPACE_METRIC_ID);
             currentIdWithNamespace.addAll(currentId);
             currentIdWithNamespace.add(Metrics.NAMESPACE_FULL_RESPONSE);
-            String metric_name = MetricRegistry.name(Metrics.NAMESPACE_PREFIX,
+            String metric_name = MetricRegistry.name(metricPrefix,
                     currentIdWithNamespace.toArray(new String[currentIdWithNamespace.size()]));
 
             ClientTimer timer = new MetricIdClientTimer(metric_name, currentId, Metrics.MetricType.FULL_RESPONSE);
@@ -62,16 +63,17 @@ public class TimerUtils {
     }
 
     private static ArrayList<Timer.Context> startFullResponseUrlTimers(MetricRegistry registry,
-                                                                       HttpRequest request) {
+                                                                       HttpRequest request,
+                                                                       String metricPrefix) {
         ArrayList<Timer.Context> timerContexts = new ArrayList<>();
         try {
             final RequestLine requestLine = request.getRequestLine();
             final String strippedUrl = Metrics.urlToMetricUrl(requestLine.getUri());
             final String method = requestLine.getMethod();
 
-            final String urlName = MetricRegistry.name(Metrics.NAMESPACE_PREFIX, Metrics.NAMESPACE_URL,
+            final String urlName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL,
                     strippedUrl, Metrics.NAMESPACE_FULL_RESPONSE);
-            final String urlAndMethodName = MetricRegistry.name(Metrics.NAMESPACE_PREFIX, Metrics.NAMESPACE_URL_AND_METHOD,
+            final String urlAndMethodName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL_AND_METHOD,
                     strippedUrl, method, Metrics.NAMESPACE_FULL_RESPONSE);
 
             ClientTimer urlTimer = new UrlClientTimer(urlName, strippedUrl, Metrics.MetricType.FULL_RESPONSE);
@@ -91,13 +93,14 @@ public class TimerUtils {
 
     public static ArrayList<Timer.Context> startFullResponseTimers(MetricRegistry clientRegistry,
                                                                    HttpRequest request,
-                                                                   String[] metricId) {
+                                                                   String[] metricId,
+                                                                   String metricNamespace) {
         if (clientRegistry != null) {
-            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry,request);
+            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace);
             ArrayList<Timer.Context> allTimerContexts = new ArrayList<>(urlTimerContexts);
             if (metricId != null) {
                 ArrayList<Timer.Context> metricIdTimers =
-                        startFullResponseMetricIdTimers(clientRegistry, metricId);
+                        startFullResponseMetricIdTimers(clientRegistry, metricId, metricNamespace);
                 allTimerContexts.addAll(metricIdTimers);
             }
             return allTimerContexts;
@@ -106,4 +109,5 @@ public class TimerUtils {
             return null;
         }
     }
+
 }

--- a/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
@@ -109,5 +109,4 @@ public class TimerUtils {
             return null;
         }
     }
-
 }

--- a/src/java/com/puppetlabs/http/client/metrics/Metrics.java
+++ b/src/java/com/puppetlabs/http/client/metrics/Metrics.java
@@ -8,6 +8,8 @@ import com.puppetlabs.http.client.impl.metrics.MetricIdClientTimerFilter;
 import com.puppetlabs.http.client.impl.metrics.TimerMetricData;
 import com.puppetlabs.http.client.impl.metrics.UrlAndMethodClientTimerFilter;
 import com.puppetlabs.http.client.impl.metrics.UrlClientTimerFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -17,13 +19,35 @@ import java.util.List;
 import java.util.Map;
 
 public class Metrics {
-    public static final String NAMESPACE_PREFIX = "puppetlabs.http-client.experimental";
+    public static final String PUPPETLABS_NAMESPACE_PREFIX = "puppetlabs";
+    public static final String HTTP_CLIENT_NAMESPACE_PREFIX = "http-client.experimental";
+    public static final String DEFAULT_NAMESPACE_PREFIX = PUPPETLABS_NAMESPACE_PREFIX +
+            "." + HTTP_CLIENT_NAMESPACE_PREFIX;
     public static final String NAMESPACE_URL = "with-url";
     public static final String NAMESPACE_URL_AND_METHOD = "with-url-and-method";
     public static final String NAMESPACE_METRIC_ID = "with-metric-id";
     public static final String NAMESPACE_FULL_RESPONSE = "full-response";
+    private static final Logger LOGGER = LoggerFactory.getLogger(Metrics.class);
+
+    public static String buildMetricNamespace(String metricPrefix, String serverId) {
+        if (metricPrefix != null) {
+            if (serverId != null) {
+                Metrics.LOGGER.warn("Metric prefix and server id both set. Using metric prefix '"
+                        + metricPrefix + "' for metric namespace.");
+            }
+            return metricPrefix + "." + HTTP_CLIENT_NAMESPACE_PREFIX;
+        } else if (serverId != null) {
+            return PUPPETLABS_NAMESPACE_PREFIX + "." + serverId + "."
+                    + HTTP_CLIENT_NAMESPACE_PREFIX;
+        } else {
+            return DEFAULT_NAMESPACE_PREFIX;
+        }
+    }
+
     public enum MetricType { FULL_RESPONSE }
     public enum MetricCategory { URL, URL_AND_METHOD, METRIC_ID }
+
+
 
     public static String urlToMetricUrl(String uriString) throws URISyntaxException {
         final URI uri = new URI(uriString);

--- a/src/java/com/puppetlabs/http/client/metrics/Metrics.java
+++ b/src/java/com/puppetlabs/http/client/metrics/Metrics.java
@@ -47,8 +47,6 @@ public class Metrics {
     public enum MetricType { FULL_RESPONSE }
     public enum MetricCategory { URL, URL_AND_METHOD, METRIC_ID }
 
-
-
     public static String urlToMetricUrl(String uriString) throws URISyntaxException {
         final URI uri = new URI(uriString);
         final URI convertedUri = new URI(uri.getScheme(), null, uri.getHost(),

--- a/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
+++ b/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
@@ -22,19 +22,22 @@
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
                                            (BasicHttpRequest. "GET" "http://localhost/foo")
-                                           nil)
+                                           nil
+                                           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are not created for a request with an empty metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
                                            (BasicHttpRequest. "GET" "http://localhost/foo")
-                                           (into-array String []))
+                                           (into-array String [])
+                                           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are created correctly for a request with a metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
                                               (BasicHttpRequest. "GET" "http://localhost/foo")
-                                              (into-array ["foo" "bar" "baz"]))
+                                              (into-array ["foo" "bar" "baz"])
+                                              Metrics/DEFAULT_NAMESPACE_PREFIX)
           (is (= (set (list url-id url-method-id
                             (add-metric-ns "with-metric-id.foo.full-response")
                             (add-metric-ns "with-metric-id.foo.bar.full-response")
@@ -45,21 +48,25 @@
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest. "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?te%2cst=one")
-           nil)
+           nil
+           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest. "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz#x%2cyz")
-           nil)
+           nil
+           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest.
             "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?te%2cst=one#x%2cyz")
-           nil)
+           nil
+           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest.
             "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?#x%2cyz")
-           nil)
+           nil
+           Metrics/DEFAULT_NAMESPACE_PREFIX)
           (is (= (set (list
                        (add-metric-ns
                         "with-url.http://localhost:1234/foo,bar/baz.full-response")
@@ -81,7 +88,8 @@
   (doseq [timer (TimerUtils/startFullResponseTimers
                  registry
                  req
-                 id)]
+                 id
+                 Metrics/DEFAULT_NAMESPACE_PREFIX)]
     (.stop timer)))
 
 (deftest get-client-metrics-data-test


### PR DESCRIPTION
Add two new client options - `server-id` and `metric-prefix` that allow the
metric namespace to be configured rather than always
`puppetlabs.http-client.experimental`.

If `server-id` is set, the metric namespace becomes
`puppetlabs.<server-id>.http-client.experimental`.

If `metric-prefix` is set, the metric namespace becomes
`<metric-prefix>.http-client.experimental`.

If both are set, `metric-prefix` wins out and a warning message is logged.