### PR TITLE
(PDB-2640) Add option for gzip compressing a request's body

### DIFF
--- a/doc/clojure-client.md
+++ b/doc/clojure-client.md
@@ -92,6 +92,11 @@ which is a map containing options for the HTTP request. These options are as fol
   with a value of `puppetlabs.core.i18n/user-locale` will be added to the
   request.
 * `:body`: optional; may be a String or any type supported by clojure's reader
+* `:compress-request-body`: optional; used to control any additional compression
+  which the client can apply to the request body before it is sent to the target
+  server. Defaults to `:none`. Supported values are:
+  * `:gzip` which will compress the request body as gzip
+  * `:none` which will not apply any additional compression to the request body
 * `:decompress-body`: optional; if `true`, an 'accept-encoding' header with a value of
   'gzip, deflate' will be added to the request, and the response will be
    automatically decompressed if it contains a recognized 'content-encoding'

--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,8 @@
   ;; depend on this source jar using a :classifier in their :dependencies.
   :classifiers [["sources" :sources-jar]]
 
-  :profiles {:dev {:dependencies [[puppetlabs/kitchensink nil :classifier "test"]
+  :profiles {:dev {:dependencies [[cheshire]
+                                  [puppetlabs/kitchensink nil :classifier "test"]
                                   [puppetlabs/trapperkeeper]
                                   [puppetlabs/trapperkeeper nil :classifier "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9]

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -42,6 +42,9 @@
 (def BodyType
   (schema/enum :text :stream :unbuffered-stream))
 
+(def CompressType
+  (schema/enum :gzip :none))
+
 (def MetricId [(schema/either schema/Str schema/Keyword)])
 
 (def RawUserRequestClientOptions
@@ -53,6 +56,7 @@
    (ok :headers)          Headers
    (ok :body)             Body
    (ok :decompress-body)  schema/Bool
+   (ok :compress-request-body) CompressType
    (ok :as)               BodyType
    (ok :query-params)     {schema/Str schema/Str}
    (ok :metric-id)        [schema/Str]
@@ -76,6 +80,7 @@
    (ok :headers)          Headers
    (ok :body)             Body
    (ok :decompress-body)  schema/Bool
+   (ok :compress-request-body) CompressType
    (ok :as)               BodyType
    (ok :query-params)     {schema/Str schema/Str}
    (ok :metric-id)        MetricId})
@@ -90,6 +95,7 @@
    :headers               Headers
    :body                  Body
    :decompress-body       schema/Bool
+   :compress-request-body CompressType
    :as                    BodyType
    (ok :query-params)     {schema/Str schema/Str}
    (ok :metric-id)        MetricId})

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -21,7 +21,9 @@
 
 (schema/defn extract-request-opts :- common/RawUserRequestOptions
   [opts :- common/RawUserRequestClientOptions]
-  (select-keys opts [:url :method :headers :body :decompress-body :as :query-params]))
+  (select-keys opts [:url :method :headers :body
+                     :decompress-body :compress-request-body
+                     :as :query-params]))
 
 (defn request-with-client
   ([req client]

--- a/src/java/com/puppetlabs/http/client/CompressType.java
+++ b/src/java/com/puppetlabs/http/client/CompressType.java
@@ -1,0 +1,6 @@
+package com.puppetlabs.http.client;
+
+public enum CompressType {
+    GZIP,
+    NONE
+}

--- a/src/java/com/puppetlabs/http/client/RequestOptions.java
+++ b/src/java/com/puppetlabs/http/client/RequestOptions.java
@@ -12,6 +12,7 @@ public class RequestOptions {
     private URI uri;
     private Map<String, String> headers;
     private Object body;
+    private CompressType requestBodyCompression = CompressType.NONE;
     private boolean decompressBody = true;
     private ResponseBodyType as = ResponseBodyType.STREAM;
     private String[] metricId;
@@ -81,6 +82,15 @@ public class RequestOptions {
     public boolean getDecompressBody() { return decompressBody; }
     public RequestOptions setDecompressBody(boolean decompressBody) {
         this.decompressBody = decompressBody;
+        return this;
+    }
+
+    public CompressType getCompressRequestBody() {
+        return requestBodyCompression;
+    }
+    public RequestOptions setCompressRequestBody(
+            CompressType requestBodyCompression) {
+        this.requestBodyCompression = requestBodyCompression;
         return this;
     }
 

--- a/src/java/com/puppetlabs/http/client/SimpleRequestOptions.java
+++ b/src/java/com/puppetlabs/http/client/SimpleRequestOptions.java
@@ -24,6 +24,7 @@ public class SimpleRequestOptions {
     private String[] sslCipherSuites;
     private boolean insecure = false;
     private Object body;
+    private CompressType requestBodyCompression = CompressType.NONE;
     private boolean decompressBody = true;
     private ResponseBodyType as = ResponseBodyType.STREAM;
     private boolean forceRedirects = false;
@@ -134,6 +135,15 @@ public class SimpleRequestOptions {
     public boolean getDecompressBody() { return decompressBody; }
     public SimpleRequestOptions setDecompressBody(boolean decompressBody) {
         this.decompressBody = decompressBody;
+        return this;
+    }
+
+    public CompressType getCompressRequestBody() {
+        return requestBodyCompression;
+    }
+    public SimpleRequestOptions setRequestBodyCompression(
+            CompressType requestBodyCompression) {
+        this.requestBodyCompression = requestBodyCompression;
         return this;
     }
 

--- a/src/java/com/puppetlabs/http/client/Sync.java
+++ b/src/java/com/puppetlabs/http/client/Sync.java
@@ -31,7 +31,12 @@ public class Sync {
         Object body = simpleOptions.getBody();
         boolean decompressBody = simpleOptions.getDecompressBody();
         ResponseBodyType as = simpleOptions.getAs();
-        return new RequestOptions(uri, headers, body, decompressBody, as);
+        CompressType requestBodyDecompression =
+                simpleOptions.getCompressRequestBody();
+        RequestOptions requestOptions = new RequestOptions(
+                uri, headers, body, decompressBody, as);
+        requestOptions.setCompressRequestBody(requestBodyDecompression);
+        return requestOptions;
     }
 
     private static ClientOptions extractClientOptions(SimpleRequestOptions simpleOptions) {

--- a/src/java/com/puppetlabs/http/client/impl/CoercedRequestOptions.java
+++ b/src/java/com/puppetlabs/http/client/impl/CoercedRequestOptions.java
@@ -5,21 +5,28 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 
 import java.net.URI;
+import java.util.zip.GZIPOutputStream;
 
-public class CoercedRequestOptions {
+class CoercedRequestOptions {
     private final URI uri;
     private final HttpMethod method;
     private final Header[] headers;
     private final HttpEntity body;
+    private final GZIPOutputStream gzipOutputStream;
+    private final byte[] bytesToGzip;
 
     public CoercedRequestOptions(URI uri,
                                  HttpMethod method,
                                  Header[] headers,
-                                 HttpEntity body) {
+                                 HttpEntity body,
+                                 GZIPOutputStream gzipOutputStream,
+                                 byte[] bytesToGzip) {
         this.uri = uri;
         this.method = method;
         this.headers = headers;
         this.body = body;
+        this.gzipOutputStream = gzipOutputStream;
+        this.bytesToGzip = bytesToGzip;
     }
 
     public URI getUri() {
@@ -37,4 +44,8 @@ public class CoercedRequestOptions {
     public HttpEntity getBody() {
         return body;
     }
+
+    public GZIPOutputStream getGzipOutputStream() { return gzipOutputStream; };
+
+    public byte[] getBytesToGzip() { return bytesToGzip; }
 }

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -386,8 +386,12 @@ public class JavaClient {
                 if (requestBody instanceof InputStream) {
                     InputStream requestInputStream = (InputStream) requestBody;
                     byte[] byteBuffer = new byte[GZIP_BUFFER_SIZE];
-                    IOUtils.copyLarge(requestInputStream,
-                            gzipOutputStream, byteBuffer);
+                    try {
+                        IOUtils.copyLarge(requestInputStream,
+                                gzipOutputStream, byteBuffer);
+                    } finally {
+                        requestInputStream.close();
+                    }
                 } else {
                     throwUnsupportedBodyException(requestBody);
                 }

--- a/test/puppetlabs/http/client/gzip_request_test.clj
+++ b/test/puppetlabs/http/client/gzip_request_test.clj
@@ -1,0 +1,118 @@
+(ns puppetlabs.http.client.gzip-request-test
+  (:import (com.puppetlabs.http.client Sync
+                                       SimpleRequestOptions
+                                       ResponseBodyType
+                                       CompressType)
+           (java.io ByteArrayInputStream)
+           (java.net URI)
+           (java.util.zip GZIPInputStream))
+  (:require [clojure.test :refer :all]
+            [cheshire.core :as cheshire]
+            [schema.test :as schema-test]
+            [puppetlabs.http.client.sync :as http-client]
+            [puppetlabs.http.client.test-common :refer :all]
+            [puppetlabs.trapperkeeper.testutils.webserver :as testwebserver]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(defn req-body-app
+  [req]
+  (let [response {:request-content-encoding (get-in req [:headers "content-encoding"])
+                  :request-body-decompressed (slurp
+                                              (GZIPInputStream. (:body req))
+                                              :encoding "utf-8")}]
+    {:status 200
+     :headers {"Content-Type" "application/json; charset=utf-8"}
+     :body (cheshire/generate-string response)}))
+
+(def short-request-body "gzip me�")
+
+(def big-request-body
+  (apply str (repeat 4000 "and�i�said�hey�yeah�yeah�whats�going�on")))
+
+(defn string->byte-array-input-stream
+  [source]
+  (-> source
+      (.getBytes)
+      (ByteArrayInputStream.)))
+
+(defn post-gzip-clj-request
+  [port body]
+  (-> (http-client/post (format "http://localhost:%d" port)
+                        {:body body
+                         :headers {"Content-Type" "text/plain; charset=utf-8"}
+                         :compress-request-body :gzip
+                         :as :text})
+      :body
+      (cheshire/parse-string true)))
+
+(defn post-gzip-java-request
+  [port body]
+  (-> (SimpleRequestOptions. (URI. (format "http://localhost:%d/hello/" port)))
+      (.setBody body)
+      (.setHeaders {"Content-Type" "text/plain; charset=utf-8"})
+      (.setRequestBodyCompression CompressType/GZIP)
+      (.setAs ResponseBodyType/TEXT)
+      (Sync/post)
+      (.getBody)
+      (cheshire/parse-string true)))
+
+(deftest clj-sync-client-gzip-requests
+  (testing "for clojure sync client"
+    (testwebserver/with-test-webserver
+     req-body-app
+     port
+     (testing "short string body is gzipped in request"
+       (let [response (post-gzip-clj-request port short-request-body)]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= short-request-body (:request-body-decompressed response)))))
+     (testing "big string body is gzipped in request"
+       (let [response (post-gzip-clj-request port big-request-body)]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= big-request-body (:request-body-decompressed response)))))
+     (testing "short inputstream body is gzipped in request"
+       (let [response (post-gzip-clj-request
+                       port
+                       (string->byte-array-input-stream short-request-body))]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= short-request-body (:request-body-decompressed response)))))
+     (testing "big inputstream body is gzipped in request"
+       (let [response (post-gzip-clj-request
+                       port
+                       (string->byte-array-input-stream big-request-body))]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= big-request-body (:request-body-decompressed response))))))))
+
+(deftest java-sync-client-gzip-requests
+  (testing "for java sync client"
+    (testwebserver/with-test-webserver
+     req-body-app
+     port
+     (testing "short string body is gzipped in request"
+       (let [response (post-gzip-java-request port short-request-body)]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= short-request-body (:request-body-decompressed response)))))
+     (testing "big string body is gzipped in request"
+       (let [response (post-gzip-java-request port big-request-body)]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= big-request-body (:request-body-decompressed response)))))
+     (testing "short inputstream body is gzipped in request"
+       (let [response (post-gzip-java-request
+                       port
+                       (string->byte-array-input-stream short-request-body))]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= short-request-body (:request-body-decompressed response)))))
+     (testing "big inputstream body is gzipped in request"
+       (let [response (post-gzip-java-request
+                       port
+                       (string->byte-array-input-stream big-request-body))]
+         (is (= "gzip" (:request-content-encoding response)))
+         (is (= big-request-body (:request-body-decompressed response))))))))
+
+(deftest connect-exception-during-gzip-request-returns-failure
+  (testing "connection exception during gzip request returns failure"
+    (is (connect-exception-thrown?
+         (http-client/post "http://localhost:65535"
+                           {:body short-request-body
+                            :compress-request-body :gzip
+                            :as :text})))))


### PR DESCRIPTION
This commit adds a new Clojure HTTP request option,
:compress-request-body`, and corresponding Java option which can be used
to have gzip compression applied to the request's body before it is sent
along to the server.