### PR TITLE
(TK-443) Allow turning off URL metrics

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,12 @@ jdk:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
+
+# Java needs to be able to resolve its hostname when doing integration style
+# tests, which it cannot do in certain cases with travis-ci.  If we need the
+# runtime/container to be able to resolve its own hostname we need to use
+# either the `hostname` or `hosts` "addon" for travis.  Since we don't care
+# what the hostname is, here we just give it a garbage name based on the name
+# of the project.
 addons:
   hostname: cljhttpclient

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,5 @@ jdk:
 script: ./ext/travisci/test.sh
 notifications:
   email: false
-
+addons:
+  hostname: cljhttpclient

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -176,13 +176,19 @@
   ([opts :- common/RawUserRequestOptions
     callback :- common/ResponseCallbackFn
     client :- HttpAsyncClient]
-    (request-with-client opts callback client nil nil true))
+   (request-with-client opts callback client nil nil true))
+  ([opts :- common/RawUserRequestOptions
+    callback :- common/ResponseCallbackFn
+    client :- HttpAsyncClient
+    metric-registry :- (schema/maybe MetricRegistry)
+    metric-namespace :- (schema/maybe schema/Str)]
+   (request-with-client opts callback client metric-registry metric-namespace true))
   ([opts :- common/RawUserRequestOptions
     callback :- common/ResponseCallbackFn
     client :- HttpAsyncClient
     metric-registry :- (schema/maybe MetricRegistry)
     metric-namespace :- (schema/maybe schema/Str)
-    enable-url-metrics? :- (schema/maybe schema/Bool)]
+    enable-url-metrics? :- schema/Bool]
    (let [result (promise)
          defaults {:body nil
                    :decompress-body true
@@ -198,12 +204,11 @@
                   (assoc :headers headers))
          java-request-options (clojure-options->java opts)
          java-method (clojure-method->java opts)
-         response-delivery-delegate (get-response-delivery-delegate opts result)
-         url-metrics (if (nil? enable-url-metrics?) true enable-url-metrics?)]
+         response-delivery-delegate (get-response-delivery-delegate opts result)]
      (JavaClient/requestWithClient java-request-options java-method callback
                                    client response-delivery-delegate metric-registry
                                    metric-namespace
-                                   url-metrics)
+                                   enable-url-metrics?)
      result)))
 
 (schema/defn create-client :- (schema/protocol common/HTTPClient)

--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -30,7 +30,7 @@
   [{:keys [ssl-context ssl-ca-cert ssl-cert ssl-key ssl-protocols cipher-suites
            follow-redirects force-redirects connect-timeout-milliseconds
            socket-timeout-milliseconds metric-registry server-id
-           metric-prefix]}:- common/ClientOptions]
+           metric-prefix use-url-metrics]}:- common/ClientOptions]
   (let [client-options (ClientOptions.)]
     (cond-> client-options
             (some? ssl-context) (.setSslContext ssl-context)
@@ -47,7 +47,8 @@
             (.setSocketTimeoutMilliseconds socket-timeout-milliseconds)
             (some? metric-registry) (.setMetricRegistry metric-registry)
             (some? server-id) (.setServerId server-id)
-            (some? metric-prefix) (.setMetricPrefix metric-prefix))
+            (some? metric-prefix) (.setMetricPrefix metric-prefix)
+            (some? use-url-metrics) (.setUseURLMetrics use-url-metrics))
     (JavaClient/createClient client-options)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -175,12 +176,13 @@
   ([opts :- common/RawUserRequestOptions
     callback :- common/ResponseCallbackFn
     client :- HttpAsyncClient]
-    (request-with-client opts callback client nil nil))
+    (request-with-client opts callback client nil nil true))
   ([opts :- common/RawUserRequestOptions
     callback :- common/ResponseCallbackFn
     client :- HttpAsyncClient
     metric-registry :- (schema/maybe MetricRegistry)
-    metric-namespace :- (schema/maybe schema/Str)]
+    metric-namespace :- (schema/maybe schema/Str)
+    use-url-metrics :- (schema/maybe schema/Bool)]
    (let [result (promise)
          defaults {:body nil
                    :decompress-body true
@@ -196,10 +198,12 @@
                   (assoc :headers headers))
          java-request-options (clojure-options->java opts)
          java-method (clojure-method->java opts)
-         response-delivery-delegate (get-response-delivery-delegate opts result)]
+         response-delivery-delegate (get-response-delivery-delegate opts result)
+         url-metrics (if (nil? use-url-metrics) true use-url-metrics)]
      (JavaClient/requestWithClient java-request-options java-method callback
                                    client response-delivery-delegate metric-registry
-                                   metric-namespace)
+                                   metric-namespace
+                                   url-metrics)
      result)))
 
 (schema/defn create-client :- (schema/protocol common/HTTPClient)
@@ -247,7 +251,8 @@
   [opts :- common/ClientOptions]
   (let [client (create-default-client opts)
         metric-registry (:metric-registry opts)
-        metric-namespace (metrics/build-metric-namespace (:metric-prefix opts) (:server-id opts))]
+        metric-namespace (metrics/build-metric-namespace (:metric-prefix opts) (:server-id opts))
+        use-url-metrics (clojure.core/get opts :use-url-metrics true)]
     (reify common/HTTPClient
       (get [this url] (common/get this url {}))
       (get [this url opts] (common/make-request this url :get opts))
@@ -269,7 +274,8 @@
       (make-request [_ url method opts] (request-with-client
                                          (assoc opts :method method :url url)
                                          nil client metric-registry
-                                         metric-namespace))
+                                         metric-namespace
+                                         use-url-metrics))
       (close [_] (.close client))
       (get-client-metric-registry [_] metric-registry)
       (get-client-metric-namespace [_] metric-namespace))))

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -116,13 +116,14 @@
    (ok :cipher-suites) [schema/Str]})
 
 (def BaseClientOptions
-  {(ok :force-redirects)  schema/Bool
+  {(ok :force-redirects) schema/Bool
    (ok :follow-redirects) schema/Bool
    (ok :connect-timeout-milliseconds) schema/Int
    (ok :socket-timeout-milliseconds) schema/Int
    (ok :metric-registry) MetricRegistry
    (ok :server-id) schema/Str
-   (ok :metric-prefix) schema/Str})
+   (ok :metric-prefix) schema/Str
+   (ok :use-url-metrics) schema/Bool})
 
 (def UserRequestOptions
   "A cleaned-up version of RawUserRequestClientOptions, which is formed after

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -123,7 +123,7 @@
    (ok :metric-registry) MetricRegistry
    (ok :server-id) schema/Str
    (ok :metric-prefix) schema/Str
-   (ok :use-url-metrics) schema/Bool})
+   (ok :enable-url-metrics?) schema/Bool})
 
 (def UserRequestOptions
   "A cleaned-up version of RawUserRequestClientOptions, which is formed after

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -28,6 +28,8 @@
 (defn request-with-client
   ([req client]
    (request-with-client req client nil nil true))
+  ([req client metric-registry metric-namespace]
+   (request-with-client req client metric-registry metric-namespace true))
   ([req client metric-registry metric-namespace enable-url-metrics?]
    (let [{:keys [error] :as resp} @(async/request-with-client
                                     req nil client metric-registry metric-namespace enable-url-metrics?)]

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -28,9 +28,9 @@
 (defn request-with-client
   ([req client]
    (request-with-client req client nil nil true))
-  ([req client metric-registry metric-namespace use-url-metrics]
+  ([req client metric-registry metric-namespace enable-url-metrics?]
    (let [{:keys [error] :as resp} @(async/request-with-client
-                                    req nil client metric-registry metric-namespace use-url-metrics)]
+                                    req nil client metric-registry metric-namespace enable-url-metrics?)]
      (if error
        (throw error)
        resp))))
@@ -47,7 +47,7 @@
   (let [client (async/create-default-client opts)
         metric-registry (:metric-registry opts)
         metric-namespace (metrics/build-metric-namespace (:metric-prefix opts) (:server-id opts))
-        use-url-metrics (clojure.core/get opts :use-url-metrics true)]
+        enable-url-metrics? (clojure.core/get opts :enable-url-metrics? true)]
     (reify common/HTTPClient
       (get [this url] (common/get this url {}))
       (get [this url opts] (common/make-request this url :get opts))
@@ -68,7 +68,7 @@
       (make-request [this url method] (common/make-request this url method {}))
       (make-request [_ url method opts] (request-with-client
                                          (assoc opts :method method :url url)
-                                         client metric-registry metric-namespace use-url-metrics))
+                                         client metric-registry metric-namespace enable-url-metrics?))
       (close [_] (.close client))
       (get-client-metric-registry [_] metric-registry)
       (get-client-metric-namespace [_] metric-namespace))))

--- a/src/java/com/puppetlabs/http/client/Async.java
+++ b/src/java/com/puppetlabs/http/client/Async.java
@@ -22,6 +22,8 @@ public class Async {
         final String metricNamespace = Metrics.buildMetricNamespace(clientOptions.getMetricPrefix(),
                 clientOptions.getServerId());
         return new PersistentAsyncHttpClient(JavaClient.createClient(clientOptions),
-                clientOptions.getMetricRegistry(),metricNamespace);
+                clientOptions.getMetricRegistry(),
+                metricNamespace,
+                clientOptions.isUseURLMetrics());
     }
 }

--- a/src/java/com/puppetlabs/http/client/Async.java
+++ b/src/java/com/puppetlabs/http/client/Async.java
@@ -24,6 +24,6 @@ public class Async {
         return new PersistentAsyncHttpClient(JavaClient.createClient(clientOptions),
                 clientOptions.getMetricRegistry(),
                 metricNamespace,
-                clientOptions.isUseURLMetrics());
+                clientOptions.isEnableURLMetrics());
     }
 }

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -29,6 +29,7 @@ public class ClientOptions {
     private MetricRegistry metricRegistry;
     private String metricPrefix;
     private String serverId;
+    private boolean useURLMetrics = true;
 
     /**
      * Constructor for the ClientOptions class. When this constructor is called,
@@ -201,6 +202,15 @@ public class ClientOptions {
 
     public ClientOptions setServerId(String serverId) {
         this.serverId = serverId;
+        return this;
+    }
+
+    public boolean isUseURLMetrics() {
+        return useURLMetrics;
+    }
+
+    public ClientOptions setUseURLMetrics(boolean useURLMetrics) {
+        this.useURLMetrics = useURLMetrics;
         return this;
     }
 }

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -29,7 +29,7 @@ public class ClientOptions {
     private MetricRegistry metricRegistry;
     private String metricPrefix;
     private String serverId;
-    private boolean useURLMetrics = true;
+    private boolean enableURLMetrics = true;
 
     /**
      * Constructor for the ClientOptions class. When this constructor is called,
@@ -205,12 +205,12 @@ public class ClientOptions {
         return this;
     }
 
-    public boolean isUseURLMetrics() {
-        return useURLMetrics;
+    public boolean isEnableURLMetrics() {
+        return enableURLMetrics;
     }
 
-    public ClientOptions setUseURLMetrics(boolean useURLMetrics) {
-        this.useURLMetrics = useURLMetrics;
+    public ClientOptions setEnableURLMetrics(boolean enableURLMetrics) {
+        this.enableURLMetrics = enableURLMetrics;
         return this;
     }
 }

--- a/src/java/com/puppetlabs/http/client/Sync.java
+++ b/src/java/com/puppetlabs/http/client/Sync.java
@@ -93,7 +93,7 @@ public class Sync {
         final String metricNamespace = Metrics.buildMetricNamespace(clientOptions.getMetricPrefix(),
                 clientOptions.getServerId());
         return new PersistentSyncHttpClient(JavaClient.createClient(clientOptions),
-                clientOptions.getMetricRegistry(), metricNamespace, clientOptions.isUseURLMetrics());
+                clientOptions.getMetricRegistry(), metricNamespace, clientOptions.isEnableURLMetrics());
     }
 
     /**

--- a/src/java/com/puppetlabs/http/client/Sync.java
+++ b/src/java/com/puppetlabs/http/client/Sync.java
@@ -93,7 +93,7 @@ public class Sync {
         final String metricNamespace = Metrics.buildMetricNamespace(clientOptions.getMetricPrefix(),
                 clientOptions.getServerId());
         return new PersistentSyncHttpClient(JavaClient.createClient(clientOptions),
-                clientOptions.getMetricRegistry(), metricNamespace);
+                clientOptions.getMetricRegistry(), metricNamespace, clientOptions.isUseURLMetrics());
     }
 
     /**

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -320,7 +320,7 @@ public class JavaClient {
                                             final MetricRegistry metricRegistry,
                                             final String[] metricId,
                                             final String metricNamespace,
-                                            final Boolean useUrlMetrics) {
+                                            final Boolean enableURLMetrics) {
 
         /*
          * Create an Apache AsyncResponseConsumer that will return the response to us as soon as it is available,
@@ -372,7 +372,7 @@ public class JavaClient {
 
         TimedFutureCallback<HttpResponse> timedStreamingCompleteCallback =
                 new TimedFutureCallback<>(streamingCompleteCallback,
-                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId, metricNamespace, useUrlMetrics));
+                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId, metricNamespace, enableURLMetrics));
         client.execute(HttpAsyncMethods.create(request), consumer, timedStreamingCompleteCallback);
     }
 
@@ -427,7 +427,7 @@ public class JavaClient {
                                          final ResponseDeliveryDelegate responseDeliveryDelegate,
                                          final MetricRegistry registry,
                                          final String metricNamespace,
-                                         final Boolean useUrlMetrics) {
+                                         final Boolean enableURLMetrics) {
 
         final CoercedRequestOptions coercedRequestOptions = coerceRequestOptions(requestOptions, method);
 
@@ -458,11 +458,11 @@ public class JavaClient {
 
         final String[] metricId = requestOptions.getMetricId();
         if (requestOptions.getAs() == ResponseBodyType.UNBUFFERED_STREAM) {
-            executeWithConsumer(client, futureCallback, request, registry, metricId, metricNamespace, useUrlMetrics);
+            executeWithConsumer(client, futureCallback, request, registry, metricId, metricNamespace, enableURLMetrics);
         } else {
             TimedFutureCallback<HttpResponse> timedFutureCallback =
                     new TimedFutureCallback<>(futureCallback,
-                            TimerUtils.startFullResponseTimers(registry, request, metricId, metricNamespace, useUrlMetrics));
+                            TimerUtils.startFullResponseTimers(registry, request, metricId, metricNamespace, enableURLMetrics));
             client.execute(request, timedFutureCallback);
         }
 

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -319,7 +319,8 @@ public class JavaClient {
                                             final HttpRequestBase request,
                                             final MetricRegistry metricRegistry,
                                             final String[] metricId,
-                                            final String metricNamespace) {
+                                            final String metricNamespace,
+                                            final Boolean useUrlMetrics) {
 
         /*
          * Create an Apache AsyncResponseConsumer that will return the response to us as soon as it is available,
@@ -371,7 +372,7 @@ public class JavaClient {
 
         TimedFutureCallback<HttpResponse> timedStreamingCompleteCallback =
                 new TimedFutureCallback<>(streamingCompleteCallback,
-                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId, metricNamespace));
+                        TimerUtils.startFullResponseTimers(metricRegistry, request, metricId, metricNamespace, useUrlMetrics));
         client.execute(HttpAsyncMethods.create(request), consumer, timedStreamingCompleteCallback);
     }
 
@@ -425,7 +426,8 @@ public class JavaClient {
                                          final CloseableHttpAsyncClient client,
                                          final ResponseDeliveryDelegate responseDeliveryDelegate,
                                          final MetricRegistry registry,
-                                         final String metricNamespace) {
+                                         final String metricNamespace,
+                                         final Boolean useUrlMetrics) {
 
         final CoercedRequestOptions coercedRequestOptions = coerceRequestOptions(requestOptions, method);
 
@@ -456,11 +458,11 @@ public class JavaClient {
 
         final String[] metricId = requestOptions.getMetricId();
         if (requestOptions.getAs() == ResponseBodyType.UNBUFFERED_STREAM) {
-            executeWithConsumer(client, futureCallback, request, registry, metricId, metricNamespace);
+            executeWithConsumer(client, futureCallback, request, registry, metricId, metricNamespace, useUrlMetrics);
         } else {
             TimedFutureCallback<HttpResponse> timedFutureCallback =
                     new TimedFutureCallback<>(futureCallback,
-                            TimerUtils.startFullResponseTimers(registry, request, metricId, metricNamespace));
+                            TimerUtils.startFullResponseTimers(registry, request, metricId, metricNamespace, useUrlMetrics));
             client.execute(request, timedFutureCallback);
         }
 

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -320,7 +320,7 @@ public class JavaClient {
                                             final MetricRegistry metricRegistry,
                                             final String[] metricId,
                                             final String metricNamespace,
-                                            final Boolean enableURLMetrics) {
+                                            final boolean enableURLMetrics) {
 
         /*
          * Create an Apache AsyncResponseConsumer that will return the response to us as soon as it is available,
@@ -427,7 +427,7 @@ public class JavaClient {
                                          final ResponseDeliveryDelegate responseDeliveryDelegate,
                                          final MetricRegistry registry,
                                          final String metricNamespace,
-                                         final Boolean enableURLMetrics) {
+                                         final boolean enableURLMetrics) {
 
         final CoercedRequestOptions coercedRequestOptions = coerceRequestOptions(requestOptions, method);
 

--- a/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
@@ -15,16 +15,16 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
-    private Boolean useURLMetrics;
+    private Boolean enableURLMetrics;
 
     public PersistentAsyncHttpClient(CloseableHttpAsyncClient client,
                                      MetricRegistry metricRegistry,
                                      String metricNamespace,
-                                     Boolean useURLMetrics) {
+                                     Boolean enableURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;
-        this.useURLMetrics = useURLMetrics;
+        this.enableURLMetrics = enableURLMetrics;
     }
 
     public void close() throws IOException {
@@ -43,7 +43,7 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null,
-                client, responseDelivery, metricRegistry, metricNamespace, useURLMetrics);
+                client, responseDelivery, metricRegistry, metricNamespace, enableURLMetrics);
         return promise;
     }
 

--- a/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
@@ -15,12 +15,12 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
-    private Boolean enableURLMetrics;
+    private boolean enableURLMetrics;
 
     public PersistentAsyncHttpClient(CloseableHttpAsyncClient client,
                                      MetricRegistry metricRegistry,
                                      String metricNamespace,
-                                     Boolean enableURLMetrics) {
+                                     boolean enableURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;

--- a/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentAsyncHttpClient.java
@@ -15,13 +15,16 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
+    private Boolean useURLMetrics;
 
     public PersistentAsyncHttpClient(CloseableHttpAsyncClient client,
                                      MetricRegistry metricRegistry,
-                                     String metricNamespace) {
+                                     String metricNamespace,
+                                     Boolean useURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;
+        this.useURLMetrics = useURLMetrics;
     }
 
     public void close() throws IOException {
@@ -40,7 +43,7 @@ public class PersistentAsyncHttpClient implements AsyncHttpClient {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null,
-                client, responseDelivery, metricRegistry, metricNamespace);
+                client, responseDelivery, metricRegistry, metricNamespace, useURLMetrics);
         return promise;
     }
 

--- a/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
@@ -18,17 +18,17 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
-    private Boolean useURLMetrics;
+    private Boolean enableURLMetrics;
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistentSyncHttpClient.class);
 
     public PersistentSyncHttpClient(CloseableHttpAsyncClient client,
                                     MetricRegistry metricRegistry,
                                     String metricNamespace,
-                                    Boolean useURLMetrics) {
+                                    Boolean enableURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;
-        this.useURLMetrics = useURLMetrics;
+        this.enableURLMetrics = enableURLMetrics;
     }
 
     private static void logAndRethrow(String msg, Throwable t) {
@@ -48,7 +48,7 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null, client,
-                responseDelivery, metricRegistry, metricNamespace, useURLMetrics);
+                responseDelivery, metricRegistry, metricNamespace, enableURLMetrics);
         Response response = null;
         try {
             response = promise.deref();

--- a/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
@@ -18,13 +18,13 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
-    private Boolean enableURLMetrics;
+    private boolean enableURLMetrics;
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistentSyncHttpClient.class);
 
     public PersistentSyncHttpClient(CloseableHttpAsyncClient client,
                                     MetricRegistry metricRegistry,
                                     String metricNamespace,
-                                    Boolean enableURLMetrics) {
+                                    boolean enableURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;

--- a/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/PersistentSyncHttpClient.java
@@ -18,14 +18,17 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
     private CloseableHttpAsyncClient client;
     private MetricRegistry metricRegistry;
     private String metricNamespace;
+    private Boolean useURLMetrics;
     private static final Logger LOGGER = LoggerFactory.getLogger(PersistentSyncHttpClient.class);
 
     public PersistentSyncHttpClient(CloseableHttpAsyncClient client,
                                     MetricRegistry metricRegistry,
-                                    String metricNamespace) {
+                                    String metricNamespace,
+                                    Boolean useURLMetrics) {
         this.client = client;
         this.metricRegistry = metricRegistry;
         this.metricNamespace = metricNamespace;
+        this.useURLMetrics = useURLMetrics;
     }
 
     private static void logAndRethrow(String msg, Throwable t) {
@@ -45,7 +48,7 @@ public class PersistentSyncHttpClient implements SyncHttpClient {
         final Promise<Response> promise = new Promise<>();
         final JavaResponseDeliveryDelegate responseDelivery = new JavaResponseDeliveryDelegate(promise);
         JavaClient.requestWithClient(requestOptions, method, null, client,
-                responseDelivery, metricRegistry, metricNamespace);
+                responseDelivery, metricRegistry, metricNamespace, useURLMetrics);
         Response response = null;
         try {
             response = promise.deref();

--- a/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
@@ -65,9 +65,9 @@ public class TimerUtils {
     private static ArrayList<Timer.Context> startFullResponseUrlTimers(MetricRegistry registry,
                                                                        HttpRequest request,
                                                                        String metricPrefix,
-                                                                       Boolean useUrlMetrics) {
+                                                                       Boolean enableURLMetrics) {
         ArrayList<Timer.Context> timerContexts = new ArrayList<>();
-        if (useUrlMetrics) {
+        if (enableURLMetrics) {
             try {
                 final RequestLine requestLine = request.getRequestLine();
                 final String strippedUrl = Metrics.urlToMetricUrl(requestLine.getUri());
@@ -98,9 +98,9 @@ public class TimerUtils {
                                                                    HttpRequest request,
                                                                    String[] metricId,
                                                                    String metricNamespace,
-                                                                   Boolean useUrlMetrics) {
+                                                                   Boolean enableURLMetrics) {
         if (clientRegistry != null) {
-            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace, useUrlMetrics);
+            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace, enableURLMetrics);
             ArrayList<Timer.Context> allTimerContexts = new ArrayList<>(urlTimerContexts);
             if (metricId != null) {
                 ArrayList<Timer.Context> metricIdTimers =

--- a/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
@@ -65,7 +65,7 @@ public class TimerUtils {
     private static ArrayList<Timer.Context> startFullResponseUrlTimers(MetricRegistry registry,
                                                                        HttpRequest request,
                                                                        String metricPrefix,
-                                                                       Boolean enableURLMetrics) {
+                                                                       boolean enableURLMetrics) {
         ArrayList<Timer.Context> timerContexts = new ArrayList<>();
         if (enableURLMetrics) {
             try {
@@ -98,7 +98,7 @@ public class TimerUtils {
                                                                    HttpRequest request,
                                                                    String[] metricId,
                                                                    String metricNamespace,
-                                                                   Boolean enableURLMetrics) {
+                                                                   boolean enableURLMetrics) {
         if (clientRegistry != null) {
             ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace, enableURLMetrics);
             ArrayList<Timer.Context> allTimerContexts = new ArrayList<>(urlTimerContexts);

--- a/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
+++ b/src/java/com/puppetlabs/http/client/impl/metrics/TimerUtils.java
@@ -64,29 +64,32 @@ public class TimerUtils {
 
     private static ArrayList<Timer.Context> startFullResponseUrlTimers(MetricRegistry registry,
                                                                        HttpRequest request,
-                                                                       String metricPrefix) {
+                                                                       String metricPrefix,
+                                                                       Boolean useUrlMetrics) {
         ArrayList<Timer.Context> timerContexts = new ArrayList<>();
-        try {
-            final RequestLine requestLine = request.getRequestLine();
-            final String strippedUrl = Metrics.urlToMetricUrl(requestLine.getUri());
-            final String method = requestLine.getMethod();
+        if (useUrlMetrics) {
+            try {
+                final RequestLine requestLine = request.getRequestLine();
+                final String strippedUrl = Metrics.urlToMetricUrl(requestLine.getUri());
+                final String method = requestLine.getMethod();
 
-            final String urlName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL,
-                    strippedUrl, Metrics.NAMESPACE_FULL_RESPONSE);
-            final String urlAndMethodName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL_AND_METHOD,
-                    strippedUrl, method, Metrics.NAMESPACE_FULL_RESPONSE);
+                final String urlName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL,
+                        strippedUrl, Metrics.NAMESPACE_FULL_RESPONSE);
+                final String urlAndMethodName = MetricRegistry.name(metricPrefix, Metrics.NAMESPACE_URL_AND_METHOD,
+                        strippedUrl, method, Metrics.NAMESPACE_FULL_RESPONSE);
 
-            ClientTimer urlTimer = new UrlClientTimer(urlName, strippedUrl, Metrics.MetricType.FULL_RESPONSE);
-            timerContexts.add(getOrAddTimer(registry, urlName, urlTimer).time());
+                ClientTimer urlTimer = new UrlClientTimer(urlName, strippedUrl, Metrics.MetricType.FULL_RESPONSE);
+                timerContexts.add(getOrAddTimer(registry, urlName, urlTimer).time());
 
-            ClientTimer urlMethodTimer = new UrlAndMethodClientTimer(urlAndMethodName, strippedUrl,
-                    method, Metrics.MetricType.FULL_RESPONSE);
-            timerContexts.add(getOrAddTimer(registry, urlAndMethodName, urlMethodTimer).time());
-        } catch (URISyntaxException e) {
-            // this shouldn't be possible
-            LOGGER.warn("Could not build URI out of the request URI. Will not create URI timers. " +
-                    "We recommend you read http://www.stilldrinking.com/programming-sucks. " +
-                    "'now all your snowflakes are urine and you can't even find the cat.'");
+                ClientTimer urlMethodTimer = new UrlAndMethodClientTimer(urlAndMethodName, strippedUrl,
+                        method, Metrics.MetricType.FULL_RESPONSE);
+                timerContexts.add(getOrAddTimer(registry, urlAndMethodName, urlMethodTimer).time());
+            } catch (URISyntaxException e) {
+                // this shouldn't be possible
+                LOGGER.warn("Could not build URI out of the request URI. Will not create URI timers. " +
+                        "We recommend you read http://www.stilldrinking.com/programming-sucks. " +
+                        "'now all your snowflakes are urine and you can't even find the cat.'");
+            }
         }
         return timerContexts;
     }
@@ -94,9 +97,10 @@ public class TimerUtils {
     public static ArrayList<Timer.Context> startFullResponseTimers(MetricRegistry clientRegistry,
                                                                    HttpRequest request,
                                                                    String[] metricId,
-                                                                   String metricNamespace) {
+                                                                   String metricNamespace,
+                                                                   Boolean useUrlMetrics) {
         if (clientRegistry != null) {
-            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace);
+            ArrayList<Timer.Context> urlTimerContexts = startFullResponseUrlTimers(clientRegistry, request, metricNamespace, useUrlMetrics);
             ArrayList<Timer.Context> allTimerContexts = new ArrayList<>(urlTimerContexts);
             if (metricId != null) {
                 ArrayList<Timer.Context> metricIdTimers =

--- a/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
+++ b/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
@@ -23,21 +23,24 @@
           (TimerUtils/startFullResponseTimers metric-registry
                                            (BasicHttpRequest. "GET" "http://localhost/foo")
                                            nil
-                                           Metrics/DEFAULT_NAMESPACE_PREFIX)
+                                           Metrics/DEFAULT_NAMESPACE_PREFIX
+                                              true)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are not created for a request with an empty metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
                                            (BasicHttpRequest. "GET" "http://localhost/foo")
                                            (into-array String [])
-                                           Metrics/DEFAULT_NAMESPACE_PREFIX)
+                                           Metrics/DEFAULT_NAMESPACE_PREFIX
+                                              true)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are created correctly for a request with a metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
                                               (BasicHttpRequest. "GET" "http://localhost/foo")
                                               (into-array ["foo" "bar" "baz"])
-                                              Metrics/DEFAULT_NAMESPACE_PREFIX)
+                                              Metrics/DEFAULT_NAMESPACE_PREFIX
+                                              true)
           (is (= (set (list url-id url-method-id
                             (add-metric-ns "with-metric-id.foo.full-response")
                             (add-metric-ns "with-metric-id.foo.bar.full-response")
@@ -49,24 +52,28 @@
            metric-registry
            (BasicHttpRequest. "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?te%2cst=one")
            nil
-           Metrics/DEFAULT_NAMESPACE_PREFIX)
+           Metrics/DEFAULT_NAMESPACE_PREFIX
+           true)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest. "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz#x%2cyz")
            nil
-           Metrics/DEFAULT_NAMESPACE_PREFIX)
+           Metrics/DEFAULT_NAMESPACE_PREFIX
+           true)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest.
             "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?te%2cst=one#x%2cyz")
            nil
-           Metrics/DEFAULT_NAMESPACE_PREFIX)
+           Metrics/DEFAULT_NAMESPACE_PREFIX
+           true)
           (TimerUtils/startFullResponseTimers
            metric-registry
            (BasicHttpRequest.
             "GET" "http://user:pwd@localhost:1234/foo%2cbar/baz?#x%2cyz")
            nil
-           Metrics/DEFAULT_NAMESPACE_PREFIX)
+           Metrics/DEFAULT_NAMESPACE_PREFIX
+           true)
           (is (= (set (list
                        (add-metric-ns
                         "with-url.http://localhost:1234/foo,bar/baz.full-response")
@@ -89,7 +96,8 @@
                  registry
                  req
                  id
-                 Metrics/DEFAULT_NAMESPACE_PREFIX)]
+                 Metrics/DEFAULT_NAMESPACE_PREFIX
+                 true)]
     (.stop timer)))
 
 (deftest get-client-metrics-data-test

--- a/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
+++ b/test/com/puppetlabs/http/client/impl/metrics_unit_test.clj
@@ -21,17 +21,17 @@
       (testing "metric id timers are not created for a request without a metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
-                                           (BasicHttpRequest. "GET" "http://localhost/foo")
-                                           nil
-                                           Metrics/DEFAULT_NAMESPACE_PREFIX
+                                              (BasicHttpRequest. "GET" "http://localhost/foo")
+                                              nil
+                                              Metrics/DEFAULT_NAMESPACE_PREFIX
                                               true)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are not created for a request with an empty metric id"
         (let [metric-registry (MetricRegistry.)]
           (TimerUtils/startFullResponseTimers metric-registry
-                                           (BasicHttpRequest. "GET" "http://localhost/foo")
-                                           (into-array String [])
-                                           Metrics/DEFAULT_NAMESPACE_PREFIX
+                                              (BasicHttpRequest. "GET" "http://localhost/foo")
+                                              (into-array String [])
+                                              Metrics/DEFAULT_NAMESPACE_PREFIX
                                               true)
           (is (= (set (list url-id url-method-id)) (set (keys (.getTimers metric-registry)))))))
       (testing "metric id timers are created correctly for a request with a metric id"

--- a/test/puppetlabs/http/client/metrics_test.clj
+++ b/test/puppetlabs/http/client/metrics_test.clj
@@ -73,7 +73,7 @@
       {:webserver {:port 10000}}
       (with-open [client (Async/createClient (doto (ClientOptions.)
                                                (.setMetricRegistry (MetricRegistry.))
-                                               (.setUseURLMetrics false)))]
+                                               (.setEnableURLMetrics false)))]
         (let [request-opts (RequestOptions. hello-url)
               response (-> client (.get request-opts) (.deref))]
           (is (= 200 (.getStatus response)))
@@ -181,7 +181,7 @@
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
       (with-open [client (async/create-client {:metric-registry (MetricRegistry.)
-                                               :use-url-metrics false})]
+                                               :enable-url-metrics? false})]
         (let [response @(common/get client hello-url)]
           (is (= 200 (:status response)))
           (let [client-metrics (-> client
@@ -279,7 +279,7 @@
       {:webserver {:port 10000}}
       (with-open [client (Sync/createClient (doto (ClientOptions.)
                                               (.setMetricRegistry (MetricRegistry.))
-                                              (.setUseURLMetrics false)))]
+                                              (.setEnableURLMetrics false)))]
         (let [request-opts (RequestOptions. hello-url)
               response (-> client (.get request-opts))]
           (is (= 200 (.getStatus response)))
@@ -388,7 +388,7 @@
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
       (with-open [client (sync/create-client {:metric-registry (MetricRegistry.)
-                                              :use-url-metrics false})]
+                                              :enable-url-metrics? false})]
         (let [response (common/get client hello-url)]
           (is (= 200 (:status response)))
           (let [client-metrics (-> client

--- a/test/puppetlabs/http/client/metrics_test.clj
+++ b/test/puppetlabs/http/client/metrics_test.clj
@@ -71,6 +71,17 @@
       app
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
+      (with-open [client (Async/createClient (doto (ClientOptions.)
+                                               (.setMetricRegistry (MetricRegistry.))
+                                               (.setUseURLMetrics false)))]
+        (let [request-opts (RequestOptions. hello-url)
+              response (-> client (.get request-opts) (.deref))]
+          (is (= 200 (.getStatus response)))
+          (let [client-metrics (-> client
+                                   (.getMetricRegistry)
+                                   (Metrics/getClientMetrics))]
+            (is (.isEmpty (.getUrlTimers client-metrics)))
+            (is (.isEmpty (.getUrlAndMethodTimers client-metrics))))))
       (let [metric-registry (MetricRegistry.)
             hello-request-opts (RequestOptions. hello-url)
             short-request-opts (RequestOptions. short-url)
@@ -169,6 +180,15 @@
       app
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
+      (with-open [client (async/create-client {:metric-registry (MetricRegistry.)
+                                               :use-url-metrics false})]
+        (let [response @(common/get client hello-url)]
+          (is (= 200 (:status response)))
+          (let [client-metrics (-> client
+                                   (common/get-client-metric-registry)
+                                   (metrics/get-client-metrics))]
+            (is (empty? (:url client-metrics)))
+            (is (empty? (:url-and-method client-metrics))))))
       (let [metric-registry (MetricRegistry.)]
         (with-open [client (async/create-client
                             {:metric-registry metric-registry})]
@@ -257,6 +277,17 @@
       app
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
+      (with-open [client (Sync/createClient (doto (ClientOptions.)
+                                              (.setMetricRegistry (MetricRegistry.))
+                                              (.setUseURLMetrics false)))]
+        (let [request-opts (RequestOptions. hello-url)
+              response (-> client (.get request-opts))]
+          (is (= 200 (.getStatus response)))
+          (let [client-metrics (-> client
+                                   (.getMetricRegistry)
+                                   (Metrics/getClientMetrics))]
+            (is (.isEmpty (.getUrlTimers client-metrics)))
+            (is (.isEmpty (.getUrlAndMethodTimers client-metrics))))))
       (let [metric-registry (MetricRegistry.)
             hello-request-opts (RequestOptions. hello-url)
             short-request-opts (RequestOptions. short-url)
@@ -356,6 +387,15 @@
       app
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
+      (with-open [client (sync/create-client {:metric-registry (MetricRegistry.)
+                                               :use-url-metrics false})]
+        (let [response (common/get client hello-url)]
+          (is (= 200 (:status response)))
+          (let [client-metrics (-> client
+                                   (common/get-client-metric-registry)
+                                   (metrics/get-client-metrics))]
+            (is (empty? (:url client-metrics)))
+            (is (empty? (:url-and-method client-metrics))))))
       (let [metric-registry (MetricRegistry.)]
         (with-open [client (sync/create-client {:metric-registry metric-registry})]
           (common/get client hello-url) ; warm it up

--- a/test/puppetlabs/http/client/metrics_test.clj
+++ b/test/puppetlabs/http/client/metrics_test.clj
@@ -388,7 +388,7 @@
       [jetty9/jetty9-service test-metric-web-service]
       {:webserver {:port 10000}}
       (with-open [client (sync/create-client {:metric-registry (MetricRegistry.)
-                                               :use-url-metrics false})]
+                                              :use-url-metrics false})]
         (let [response (common/get client hello-url)]
           (is (= 200 (:status response)))
           (let [client-metrics (-> client


### PR DESCRIPTION
The primary consumer for this library (puppetserver) passes metric ids
for all metrics it's concerned about and does not need to use any of the
autogenerated url metrics.

This patch allows configuring whether or not to generate url metrics.
It parameterizes the clojure async and sync clients, and adds a
commensurate field to ClientOptions for Java clients.  The default is to
enable url metrics for compatability.

The actual functionality was plumbed by @rlinehan 