### PR TITLE
(PE-26658) update clj-parent to pick up fips work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,23 @@ jobs:
     - stage: jdk8
       script: lein with-profile dev test
       jdk: openjdk8
-    #- # same as previous stage
-    #  script: lein with-profile fips test
-    #  jdk: openjdk8
+      env:
+        - FIPS=false
+    - # same as previous stage
+      script: lein with-profile fips test
+      jdk: openjdk8
+      env:
+        - FIPS=true
     - stage: jdk11
       script: lein with-profile dev test
       jdk: openjdk11
-    #- # same as previous stage
-    #  script: lein with-profile fips test
-    #  jdk: openjdk11
+      env:
+        - FIPS=false
+    - # same as previous stage
+      script: lein with-profile fips test
+      jdk: openjdk11
+      env:
+        - FIPS=true
 sudo: false
 # Java needs to be able to resolve its hostname when doing integration style
 # tests, which it cannot do in certain cases with travis-ci.  If we need the

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.4"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in


### PR DESCRIPTION
Updates clj-parent for new clj-http-client and enables FIPS tests