### PR TITLE
(PE-27189) disambiguate ambiguous type specifications

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
 
   :min-lein-version "2.9.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "4.2.3"]
+  :parent-project {:coords [puppetlabs/clj-parent "4.2.10"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -1,5 +1,5 @@
 (ns puppetlabs.http.client.common
-  (:import (java.net URL)
+  (:import (java.net URL URI)
            (javax.net.ssl SSLContext)
            (com.codahale.metrics MetricRegistry)
            (clojure.lang IBlockingDeref)
@@ -31,6 +31,7 @@
 
 (def ok schema/optional-key)
 
+(def UrlOrUriOrString (schema/either schema/Str URL URI))
 (def UrlOrString (schema/either schema/Str URL))
 
 (def Headers
@@ -51,7 +52,7 @@
   "The list of request and client options passed by a user into
   the request function. Allows the user to configure
   both a client and a request."
-  {:url                   UrlOrString
+  {:url                   UrlOrUriOrString
    :method                schema/Keyword
    (ok :headers)          Headers
    (ok :body)             Body
@@ -75,7 +76,7 @@
 (def RawUserRequestOptions
   "The list of request options passed by a user into the
   request function. Allows the user to configure a request."
-  {:url                   UrlOrString
+  {:url                   UrlOrUriOrString
    :method                schema/Keyword
    (ok :headers)          Headers
    (ok :body)             Body
@@ -90,7 +91,7 @@
   configuration and settings for an individual request. This is
   everything from UserRequestOptions not included in
   ClientOptions."
-  {:url                   UrlOrString
+  {:url                   UrlOrUriOrString
    :method                schema/Keyword
    :headers               Headers
    :body                  Body

--- a/test/puppetlabs/http/client/async_unbuffered_test.clj
+++ b/test/puppetlabs/http/client/async_unbuffered_test.clj
@@ -89,8 +89,8 @@
               ;; Consume the body to get the exception
               (is (thrown? SocketTimeoutException (slurp body))))))
          (catch TimeoutException e
-           ;; Expected whenever a server-side failure is generated
-           )))
+                ;; Expected whenever a server-side failure is generated
+                nil)))
 
      (testing " - check connection timeout is handled"
        (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
@@ -137,7 +137,8 @@
             (is (instance? SocketTimeoutException error)))))
        (catch TimeoutException e
          ;; Expected whenever a server-side failure is generated
-         )))
+         nil)))
+
 
    (testing " - check connection timeout is handled"
      (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
@@ -223,7 +224,8 @@
                 (is (thrown? SocketTimeoutException (slurp body))))))
           (catch TimeoutException e
             ;; Expected whenever a server-side failure is generated
-            )))
+            nil)))
+
 
       (testing " - check connection timeout is handled"
         (with-open [client (-> (ClientOptions.)
@@ -286,7 +288,8 @@
               (is (instance? SocketTimeoutException error)))))
         (catch TimeoutException e
           ;; Expected whenever a server-side failure is generated
-          )))
+          nil)))
+
 
     (testing " - check connection timeout is handled"
       (with-open [client (-> (ClientOptions.)


### PR DESCRIPTION
Bumps clj-parent to 4.2.10

There have been issues seen with clj and java11 where clojure is unable
to find the class associated with specific java interop calls.  In this
case, the "RequestOptions" constructor was occasionally ambigous.  In
order to rectify this issue, in all places where there is some ambiguity,
type assertions are added.

In addition, there was some type issues with the common/RequestOptions
ahd how it was handled.  With the exiting code, there is one consistent
path through RequestOptions that passes a URI.  Schema type assertions
were added to demonstrate and validate the behavior, and tests were
created to demonstrate the correct handling of URL and URI types for
url specification.