### PR TITLE
(SERVER-2780) Add reason phrase to HTTP response

### DIFF
--- a/src/clj/puppetlabs/http/client/async.clj
+++ b/src/clj/puppetlabs/http/client/async.clj
@@ -84,10 +84,11 @@
    result :- common/ResponsePromise]
   (reify ResponseDeliveryDelegate
     (deliverResponse
-      [_ _ orig-encoding body headers status content-type callback]
+      [_ _ orig-encoding body headers status-code reason-phrase content-type callback]
       (->> {:opts                  opts
             :orig-content-encoding orig-encoding
-            :status                status
+            :status                status-code
+            :reason-phrase         reason-phrase
             :headers               (into {} headers)
             :content-type          (java-content-type->clj content-type)
             :body                  body}

--- a/src/clj/puppetlabs/http/client/common.clj
+++ b/src/clj/puppetlabs/http/client/common.clj
@@ -163,6 +163,7 @@
    :body Body
    :headers Headers
    :status schema/Int
+   :reason-phrase schema/Str
    :content-type ContentType})
 
 (def ErrorResponse

--- a/src/java/com/puppetlabs/http/client/Response.java
+++ b/src/java/com/puppetlabs/http/client/Response.java
@@ -15,6 +15,7 @@ public class Response {
     private Object body;
     private Map<String, String> headers;
     private Integer status;
+    private String reasonPhrase;
     private ContentType contentType;
 
     public Response(RequestOptions options, Throwable error) {
@@ -24,12 +25,13 @@ public class Response {
 
     public Response(RequestOptions options, String origContentEncoding,
                     Object body, Map<String, String> headers, int status,
-                    ContentType contentType) {
+                    String reasonPhrase, ContentType contentType) {
         this.options = options;
         this.origContentEncoding = origContentEncoding;
         this.body = body;
         this.headers = headers;
         this.status = status;
+        this.reasonPhrase = reasonPhrase;
         this.contentType = contentType;
     }
 
@@ -54,6 +56,10 @@ public class Response {
 
     public Integer getStatus() {
         return status;
+    }
+
+    public String getReasonPhrase() {
+        return reasonPhrase;
     }
 
     public ContentType getContentType() { return contentType; }

--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -16,6 +16,7 @@ import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
+import org.apache.http.StatusLine;
 import org.apache.http.ParseException;
 import org.apache.http.ProtocolException;
 import org.apache.http.client.RedirectStrategy;
@@ -317,11 +318,13 @@ public class JavaClient {
             if (requestOptions.getAs() == ResponseBodyType.TEXT) {
                 body = coerceBodyType((InputStream) body, requestOptions.getAs(), contentType);
             }
+            StatusLine status = httpResponse.getStatusLine();
             responseDeliveryDelegate.deliverResponse(requestOptions,
                     origContentEncoding,
                     body,
                     headers,
-                    httpResponse.getStatusLine().getStatusCode(),
+                    status.getStatusCode(),
+                    status.getReasonPhrase(),
                     contentType,
                     callback);
         } catch (Exception e) {

--- a/src/java/com/puppetlabs/http/client/impl/JavaResponseDeliveryDelegate.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaResponseDeliveryDelegate.java
@@ -32,6 +32,7 @@ public final class JavaResponseDeliveryDelegate implements ResponseDeliveryDeleg
                                 Object body,
                                 Map<String, String> headers,
                                 int statusCode,
+                                String reasonPhrase,
                                 ContentType contentType,
                                 IResponseCallback callback) {
         Response response = new Response(requestOptions,
@@ -39,6 +40,7 @@ public final class JavaResponseDeliveryDelegate implements ResponseDeliveryDeleg
                 body,
                 headers,
                 statusCode,
+                reasonPhrase,
                 contentType);
         deliverResponse(response, requestOptions, callback);
     }

--- a/src/java/com/puppetlabs/http/client/impl/ResponseDeliveryDelegate.java
+++ b/src/java/com/puppetlabs/http/client/impl/ResponseDeliveryDelegate.java
@@ -10,6 +10,7 @@ public interface ResponseDeliveryDelegate {
                          Object body,
                          java.util.Map<String, String> headers,
                          int statusCode,
+                         String reasonPhrase,
                          ContentType contentType,
                          IResponseCallback callback);
 

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -71,9 +71,15 @@
         (let [request-options (RequestOptions. (URI. "http://localhost:10000/hello/"))
               client-options (ClientOptions.)
               client (Async/createClient client-options)]
+          (testing "HEAD request to missing endpoint"
+            (let [response (.head client
+                                  (RequestOptions. (URI. "http://localhost:10000/missing")))]
+              (is (= 404 (.getStatus (.deref response))))
+              (is (= "Not Found" (.getReasonPhrase (.deref response))))))
           (testing "HEAD request with persistent async client"
             (let [response (.head client request-options)]
               (is (= 200 (.getStatus (.deref response))))
+              (is (= "OK" (.getReasonPhrase (.deref response))))
               (is (= nil (.getBody (.deref response))))))
           (testing "GET request with persistent async client"
             (let [response (.get client request-options)]
@@ -109,9 +115,14 @@
                          (.get client request-options))))))
       (testing "clojure async client"
         (let [client (async/create-client {})]
+          (testing "HEAD request to missing endpoint"
+            (let [response (common/head client "http://localhost:10000/missing")]
+              (is (= 404 (:status @response)))
+              (is (= "Not Found" (:reason-phrase @response)))))
           (testing "HEAD request with persistent async client"
             (let [response (common/head client "http://localhost:10000/hello/")]
               (is (= 200 (:status @response)))
+              (is (= "OK" (:reason-phrase @response)))
               (is (= nil (:body @response)))))
           (testing "GET request with persistent async client"
             (let [response (common/get client "http://localhost:10000/hello/")]

--- a/test/puppetlabs/http/client/async_plaintext_test.clj
+++ b/test/puppetlabs/http/client/async_plaintext_test.clj
@@ -65,96 +65,96 @@
 (deftest persistent-async-client-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-    [jetty9/jetty9-service test-web-service]
-    {:webserver {:port 10000}}
-    (testing "java async client"
-      (let [request-options (RequestOptions. (URI. "http://localhost:10000/hello/"))
-            client-options (ClientOptions.)
-            client (Async/createClient client-options)]
-        (testing "HEAD request with persistent async client"
-          (let [response (.head client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= nil (.getBody (.deref response))))))
-        (testing "GET request with persistent async client"
-          (let [response (.get client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "POST request with persistent async client"
-          (let [response (.post client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "PUT request with persistent async client"
-          (let [response (.put client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "DELETE request with persistent async client"
-          (let [response (.delete client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "TRACE request with persistent async client"
-          (let [response (.trace client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "OPTIONS request with persistent async client"
-          (let [response (.options client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "PATCH request with persistent async client"
-          (let [response (.patch client request-options)]
-            (is (= 200 (.getStatus (.deref response))))
-            (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
-        (testing "client closes properly"
-          (.close client)
-          (is (thrown? IllegalStateException
-                       (.get client request-options))))))
-    (testing "clojure async client"
-      (let [client (async/create-client {})]
-        (testing "HEAD request with persistent async client"
-          (let [response (common/head client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= nil (:body @response)))))
-        (testing "GET request with persistent async client"
-          (let [response (common/get client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "POST request with persistent async client"
-          (let [response (common/post client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "PUT request with persistent async client"
-          (let [response (common/put client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "DELETE request with persistent async client"
-          (let [response (common/delete client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "TRACE request with persistent async client"
-          (let [response (common/trace client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "OPTIONS request with persistent async client"
-          (let [response (common/options client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "PATCH request with persistent async client"
-          (let [response (common/patch client "http://localhost:10000/hello/")]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "GET request via request function with persistent async client"
-          (let [response (common/make-request client "http://localhost:10000/hello/" :get)]
-            (is (= 200 (:status @response)))
-            (is (= "Hello, World!" (slurp (:body @response))))))
-        (testing "Bad verb request via request function with persistent async client"
-          (is (thrown? IllegalArgumentException
-                       (common/make-request client
-                                            "http://localhost:10000/hello/"
-                                            :bad))))
-        (testing "client closes properly"
-          (common/close client)
-          (is (thrown? IllegalStateException
-                       (common/get client
-                                   "http://localhost:10000/hello/")))))))))
+      [jetty9/jetty9-service test-web-service]
+      {:webserver {:port 10000}}
+      (testing "java async client"
+        (let [request-options (RequestOptions. (URI. "http://localhost:10000/hello/"))
+              client-options (ClientOptions.)
+              client (Async/createClient client-options)]
+          (testing "HEAD request with persistent async client"
+            (let [response (.head client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= nil (.getBody (.deref response))))))
+          (testing "GET request with persistent async client"
+            (let [response (.get client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "POST request with persistent async client"
+            (let [response (.post client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "PUT request with persistent async client"
+            (let [response (.put client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "DELETE request with persistent async client"
+            (let [response (.delete client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "TRACE request with persistent async client"
+            (let [response (.trace client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "OPTIONS request with persistent async client"
+            (let [response (.options client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "PATCH request with persistent async client"
+            (let [response (.patch client request-options)]
+              (is (= 200 (.getStatus (.deref response))))
+              (is (= "Hello, World!" (slurp (.getBody (.deref response)))))))
+          (testing "client closes properly"
+            (.close client)
+            (is (thrown? IllegalStateException
+                         (.get client request-options))))))
+      (testing "clojure async client"
+        (let [client (async/create-client {})]
+          (testing "HEAD request with persistent async client"
+            (let [response (common/head client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= nil (:body @response)))))
+          (testing "GET request with persistent async client"
+            (let [response (common/get client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "POST request with persistent async client"
+            (let [response (common/post client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "PUT request with persistent async client"
+            (let [response (common/put client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "DELETE request with persistent async client"
+            (let [response (common/delete client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "TRACE request with persistent async client"
+            (let [response (common/trace client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "OPTIONS request with persistent async client"
+            (let [response (common/options client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "PATCH request with persistent async client"
+            (let [response (common/patch client "http://localhost:10000/hello/")]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "GET request via request function with persistent async client"
+            (let [response (common/make-request client "http://localhost:10000/hello/" :get)]
+              (is (= 200 (:status @response)))
+              (is (= "Hello, World!" (slurp (:body @response))))))
+          (testing "Bad verb request via request function with persistent async client"
+            (is (thrown? IllegalArgumentException
+                         (common/make-request client
+                                              "http://localhost:10000/hello/"
+                                              :bad))))
+          (testing "client closes properly"
+            (common/close client)
+            (is (thrown? IllegalStateException
+                         (common/get client
+                                     "http://localhost:10000/hello/")))))))))
 
 (deftest java-api-cookie-test
   (testlogging/with-test-logging

--- a/test/puppetlabs/http/client/sync_plaintext_test.clj
+++ b/test/puppetlabs/http/client/sync_plaintext_test.clj
@@ -63,10 +63,12 @@
           (let [request-options (SimpleRequestOptions. (URI. "http://localhost:10000/hello/"))
                 response (java-method request-options)]
             (is (= 200 (.getStatus response)))
+            (is (= "OK" (.getReasonPhrase response)))
             (is (= "Hello, World!" (slurp (.getBody response))))))
         (testing "clojure sync client"
           (let [response (clj-fn "http://localhost:10000/hello/")]
             (is (= 200 (:status response)))
+            (is (= "OK" (:reason-phrase response)))
             (is (= "Hello, World!" (slurp (:body response))))))))))
 
 (deftest sync-client-head-test
@@ -82,7 +84,11 @@
       (testing "clojure sync client"
         (let [response (sync/head "http://localhost:10000/hello/")]
           (is (= 200 (:status response)))
-          (is (= nil (:body response))))))))
+          (is (= nil (:body response)))))
+      (testing "not found"
+        (let [response (sync/head "http://localhost:10000/missing")]
+          (is (= 404 (:status response)))
+          (is (= "Not Found" (:reason-phrase response))))))))
 
 (deftest sync-client-get-test
   (basic-test "GET" #(Sync/get %) sync/get))

--- a/test/puppetlabs/http/client/sync_plaintext_test.clj
+++ b/test/puppetlabs/http/client/sync_plaintext_test.clj
@@ -108,96 +108,96 @@
 (deftest sync-client-persistent-test
   (testlogging/with-test-logging
     (testutils/with-app-with-config app
-    [jetty9/jetty9-service test-web-service]
-    {:webserver {:port 10000}}
-    (testing "persistent java client"
-      (let [request-options (RequestOptions. "http://localhost:10000/hello/")
-            client-options (ClientOptions.)
-            client (Sync/createClient client-options)]
-        (testing "HEAD request with persistent sync client"
-          (let [response (.head client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= nil (.getBody response)))))
-        (testing "GET request with persistent sync client"
-          (let [response (.get client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "POST request with persistent sync client"
-          (let [response (.post client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "PUT request with persistent sync client"
-          (let [response (.put client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "DELETE request with persistent sync client"
-          (let [response (.delete client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "TRACE request with persistent sync client"
-          (let [response (.trace client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "OPTIONS request with persistent sync client"
-          (let [response (.options client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "PATCH request with persistent sync client"
-          (let [response (.patch client request-options)]
-            (is (= 200 (.getStatus response)))
-            (is (= "Hello, World!" (slurp (.getBody response))))))
-        (testing "client closes properly"
-          (.close client)
-          (is (thrown? IllegalStateException
-                       (.get client request-options))))))
-    (testing "persistent clojure client"
-      (let [client (sync/create-client {})]
-        (testing "HEAD request with persistent sync client"
-          (let [response (common/head client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= nil (:body response)))))
-        (testing "GET request with persistent sync client"
-          (let [response (common/get client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "POST request with persistent sync client"
-          (let [response (common/post client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "PUT request with persistent sync client"
-          (let [response (common/put client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "DELETE request with persistent sync client"
-          (let [response (common/delete client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "TRACE request with persistent sync client"
-          (let [response (common/trace client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "OPTIONS request with persistent sync client"
-          (let [response (common/options client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "PATCH request with persistent sync client"
-          (let [response (common/patch client "http://localhost:10000/hello/")]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "GET request via request function with persistent sync client"
-          (let [response (common/make-request client "http://localhost:10000/hello/" :get)]
-            (is (= 200 (:status response)))
-            (is (= "Hello, World!" (slurp (:body response))))))
-        (testing "Bad verb request via request function with persistent sync client"
-          (is (thrown? IllegalArgumentException
-                       (common/make-request client
-                                            "http://localhost:10000/hello/"
-                                            :bad))))
-        (testing "client closes properly"
-          (common/close client)
-          (is (thrown? IllegalStateException
-                       (common/get client
-                                   "http://localhost:10000/hello")))))))))
+      [jetty9/jetty9-service test-web-service]
+      {:webserver {:port 10000}}
+      (testing "persistent java client"
+        (let [request-options (RequestOptions. "http://localhost:10000/hello/")
+              client-options (ClientOptions.)
+              client (Sync/createClient client-options)]
+          (testing "HEAD request with persistent sync client"
+            (let [response (.head client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= nil (.getBody response)))))
+          (testing "GET request with persistent sync client"
+            (let [response (.get client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "POST request with persistent sync client"
+            (let [response (.post client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "PUT request with persistent sync client"
+            (let [response (.put client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "DELETE request with persistent sync client"
+            (let [response (.delete client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "TRACE request with persistent sync client"
+            (let [response (.trace client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "OPTIONS request with persistent sync client"
+            (let [response (.options client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "PATCH request with persistent sync client"
+            (let [response (.patch client request-options)]
+              (is (= 200 (.getStatus response)))
+              (is (= "Hello, World!" (slurp (.getBody response))))))
+          (testing "client closes properly"
+            (.close client)
+            (is (thrown? IllegalStateException
+                         (.get client request-options))))))
+      (testing "persistent clojure client"
+        (let [client (sync/create-client {})]
+          (testing "HEAD request with persistent sync client"
+            (let [response (common/head client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= nil (:body response)))))
+          (testing "GET request with persistent sync client"
+            (let [response (common/get client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "POST request with persistent sync client"
+            (let [response (common/post client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "PUT request with persistent sync client"
+            (let [response (common/put client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "DELETE request with persistent sync client"
+            (let [response (common/delete client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "TRACE request with persistent sync client"
+            (let [response (common/trace client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "OPTIONS request with persistent sync client"
+            (let [response (common/options client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "PATCH request with persistent sync client"
+            (let [response (common/patch client "http://localhost:10000/hello/")]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "GET request via request function with persistent sync client"
+            (let [response (common/make-request client "http://localhost:10000/hello/" :get)]
+              (is (= 200 (:status response)))
+              (is (= "Hello, World!" (slurp (:body response))))))
+          (testing "Bad verb request via request function with persistent sync client"
+            (is (thrown? IllegalArgumentException
+                         (common/make-request client
+                                              "http://localhost:10000/hello/"
+                                              :bad))))
+          (testing "client closes properly"
+            (common/close client)
+            (is (thrown? IllegalStateException
+                         (common/get client
+                                     "http://localhost:10000/hello")))))))))
 
 (deftest sync-client-as-test
   (testlogging/with-test-logging


### PR DESCRIPTION
This commit adds an additional field to the Response object: the status
message or reason phrase that goes along with the HTTP code. This allows
us to better match the API for Puppet's HTTP response object, for
ruby/java interop in puppetserver.