### PR TITLE
(PE-33177) Update ClientOptions default SSL protocols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,30 @@
+dist: bionic
 language: clojure
 lein: 2.9.1
 jobs:
   include:
-    - stage: jdk8
-      script: lein with-profile dev test
-      jdk: openjdk8
+    # The OpenJDK versions used by Travis are pretty old, which causes
+    # problems with some of the tests. This pulls in a semi-recent version
+    # from the Ubuntu repos.
+    - name: jdk8
+      before_install: 
+        - sudo rm -rf /usr/local/lib/jvm/
+        - sudo rm -rf /usr/lib/jvm/openjdk-8
+        - sudo apt-get install -y openjdk-8-jdk-headless
+        - export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/
+      script:
+        - lein with-profile dev test
     #- # same as previous stage
     #  script: lein with-profile fips test
     #  jdk: openjdk8
-    - stage: jdk11
-      script: lein with-profile dev test
-      jdk: openjdk11
+    - name: jdk11
+      before_install: 
+        - sudo rm -rf /usr/local/lib/jvm/
+        - sudo rm -rf /usr/lib/jvm/openjdk-11
+        - sudo apt-get install -y openjdk-11-jdk-headless
+        - export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+      script:
+        - lein with-profile dev test
     #- # same as previous stage
     #  script: lein with-profile fips test
     #  jdk: openjdk11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.0.0
+* [PE-33177](https://tickets.puppetlabs.com/browse/PE-33177) Add TLSv1.3 to ClientOptions default SSL protocols and remove TLSv1 and TLSv1.1.
+
 ## 1.2.4
 * Public release of 1.2.3, no other changes.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/http-client "1.2.5-SNAPSHOT"
+(defproject puppetlabs/http-client "2.0.0-SNAPSHOT"
   :description "HTTP client wrapper"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}

--- a/src/java/com/puppetlabs/http/client/ClientOptions.java
+++ b/src/java/com/puppetlabs/http/client/ClientOptions.java
@@ -18,7 +18,7 @@ import java.security.Security;
  */
 public class ClientOptions {
     public static final String[] DEFAULT_SSL_PROTOCOLS =
-            new String[] {"TLSv1", "TLSv1.1", "TLSv1.2"};
+            new String[] {"TLSv1.3", "TLSv1.2"};
 
     private SSLContext sslContext;
     private String sslCert;

--- a/test/puppetlabs/http/client/sync_ssl_test.clj
+++ b/test/puppetlabs/http/client/sync_ssl_test.clj
@@ -140,7 +140,8 @@
              (and (instance? SSLException cause#)
                   (or (re-find #"handshake_failure" message#)
                       (re-find #"internal_error" message#)))
-             (instance? ConnectionClosedException cause#))))))
+             (instance? ConnectionClosedException cause#))))
+     (catch ConnectionClosedException cce# true)))
 
 (defn java-https-get-with-protocols
   [client-protocols client-cipher-suites]
@@ -183,5 +184,5 @@
         (is (java-unsupported-protocol-exception?
               (java-https-get-with-protocols ["TLSv1.2"] nil))))
       (testing "clojure sync client"
-        (is (thrown? SSLException (clj-https-get-with-protocols ["TLSv1.2"] nil)))))))
+        (is (java-unsupported-protocol-exception? (clj-https-get-with-protocols ["TLSv1.2"] nil)))))))
 


### PR DESCRIPTION
### (PE-33177) Update ClientOptions default SSL protocols 
This updates the DEFAULT_SSL_PROTOCOLS variable to TLSv1.2 and TLSv1.3, to be in line with the desired defaults used in Puppet and PE.

### (PE-33177) Update exception handling in sync_ssl_test for clojure sync client
The clojure sync client now throws a ConnectionClosedException, rather than an SSLException, when a connection can't be established due to no valid protocols. This happens in the latest Java 11 versions, but older Java 11 versions (e.g. 11.0.2 used by Travis) still throws an SSLHandshakeException.  This commit changes java-unsupported-protocol-exception? to be able to handle both of these cases.

Note that there still seems to be cases where ConnectionClosedException is picked up by the HttpClientException block (using the Java sync client) and some cases where it isn't (Clojure sync client).

### (PE-33177) Update CHANGELOG and bump project version 
Creating a new major since this removes TLSv1 and TLSv1.1 from the defaults.

### (PE-33177) Update Travis to use more recent builds for java 8 and 11 
The versions of Java Travis has pre-installed are pretty old. The sync_ssl_test is looking for particular exceptions that have changed since these old versions. This changes the instructions for Travis to install OpenJDK from the Ubuntu repos, which are more up to date (though still not latest).

This also modifies the jobs to run in parallel, rather than sequentially, since they don't depend on each other. This wil save some time.