### PR TITLE
(maint) Use `OPTIONS` request method when calling the sync client's `options` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+* Use `OPTIONS` request method when calling the synchronous client's `options` function.
+
 ## 2.0.0
 * [PE-33177](https://tickets.puppetlabs.com/browse/PE-33177) Add TLSv1.3 to ClientOptions default SSL protocols and remove TLSv1 and TLSv1.1.
 

--- a/src/clj/puppetlabs/http/client/sync.clj
+++ b/src/clj/puppetlabs/http/client/sync.clj
@@ -66,7 +66,7 @@
       (trace [this url] (common/trace this url {}))
       (trace [this url opts] (common/make-request this url :trace opts))
       (options [this url] (common/options this url {}))
-      (options [this url opts] (common/make-request this url :post opts))
+      (options [this url opts] (common/make-request this url :options opts))
       (patch [this url] (common/patch this url {}))
       (patch [this url opts] (common/make-request this url :patch opts))
       (make-request [this url method] (common/make-request this url method {}))


### PR DESCRIPTION
Presumably from a bad copy+paste, the `options` function was previously using
the `POST` method to make requests, making it identical to the `post` function.