### PR TITLE
(PE-34843) Properly reuse connections with a client cert

### DIFF
--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -532,6 +532,15 @@ public class JavaClient {
         HttpAsyncClientBuilder clientBuilder = HttpAsyncClients.custom();
         clientBuilder.setMaxConnPerRoute(clientOptions.getMaxConnectionsPerRoute());
         clientBuilder.setMaxConnTotal(clientOptions.getMaxConnectionsTotal());
+        // Typically, the HttpClient library tracks the "user token" for a
+        // connection, which in our case is the SSL certificate name, and
+        // refuses to reuse a connection if the SSL certificate is different
+        // for the next request. Because we create a new HttpClientContext for
+        // every request, this tracking doesn't work in our case. However,
+        // since we bake the SSL context in at the time we create the client,
+        // it's impossible for it to change from request to request, so we can
+        // simply disable that tracking altogether.
+        clientBuilder.disableConnectionState();
 
         SSLContext context = coercedOptions.getSslContext();
         if (context != null) {


### PR DESCRIPTION
The apache http client library has the concept of "stateless" and
"stateful" connections, where a stateful connection is one made with an
associated user identity (either NTLM or an SSL certificate). The
default implementation tracks this information (which it refers to as
the "user token") on the HTTP context and uses it to avoid reusing a
connection when the user token has changed.

Because we create a new HTTP context for every request, we don't
properly track that token, meaning each time the client tries to reuse a
connection, it finds that the token has changed (it thinks the old value
is null, the the new value is not null) and rejects the connection. This
creates a substantial performance hit in cases where we make many
requests in a row.

Because we define the SSL context at the time the client is *created*
and not when it's *used*, it's impossible for it to change between
requests. Therefore, we can simply disable the connection state tracking
feature entirely.