### PR TITLE
(maint) ensure unbuffered-stream correctly handles 204 responses 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+# 2.1.3
+* ensure unbuffered-stream correctly handles 204 responses with no body in the response.
+
 # 2.1.2
 * add support for multiple `Set-Cookie` headers in a response separated by newlines. 
 * update project.clj to remove composite profiles that include maps, it is deprecated in lein 2.11.0

--- a/test/puppetlabs/http/client/async_unbuffered_test.clj
+++ b/test/puppetlabs/http/client/async_unbuffered_test.clj
@@ -324,3 +324,13 @@
 (deftest java-existing-streaming-with-large-payload-with-decompression
   (testing "java :stream with 1M payload and decompression"
     (java-blocking-streaming (generate-data (* 1024 1024)) ResponseBodyType/STREAM true)))
+
+(deftest java-204-streaming
+  (testing "client handles a webserver that returns a 204 response and no body correctly"
+    (testwebserver/with-test-webserver-and-config
+      (constantly {:status 204}) port {:shutdown-timeout-seconds 1}
+      (with-open [client (async/create-client {:connect-timeout-milliseconds 100})]
+        (let [response @(common/post client (str "http://localhost:" port "/something") {:method :post
+                                                                                         :as :unbuffered-stream})]
+          (is (= 204 (:status response))))))))
+


### PR DESCRIPTION
In the case that an unbuffered stream is used and the server responds
in a 204, with no response, the client was throwing an exception because
the entity in the response is null. This adds a test that demonstrates
the failure, and fixes the underlying issue.