### PR TITLE
(maint) Move failure logging to debug level

### DIFF
--- a/src/java/com/puppetlabs/http/client/impl/JavaClient.java
+++ b/src/java/com/puppetlabs/http/client/impl/JavaClient.java
@@ -344,7 +344,7 @@ public class JavaClient {
                     contentType,
                     callback);
         } catch (Exception e) {
-            LOGGER.error("Processing successful request to {} raised '{}'", requestOptions.getUri().toString(), e.getMessage());
+            LOGGER.debug("Processing successful request to {} raised '{}'", requestOptions.getUri().toString(), e.getMessage());
             responseDeliveryDelegate.deliverResponse(requestOptions, e, callback);
         }
     }
@@ -480,13 +480,13 @@ public class JavaClient {
 
             @Override
             public void failed(Exception e) {
-                LOGGER.error("{} request to '{}' failed.", method.toString(), requestOptions.getUri().toString());
+                LOGGER.debug("{} request to '{}' failed.", method.toString(), requestOptions.getUri().toString());
                 responseDeliveryDelegate.deliverResponse(requestOptions, e, callback);
             }
 
             @Override
             public void cancelled() {
-                LOGGER.error("{} request to '{}' cancelled.", method.toString(), requestOptions.getUri().toString());
+                LOGGER.debug("{} request to '{}' cancelled.", method.toString(), requestOptions.getUri().toString());
                 responseDeliveryDelegate.deliverResponse(requestOptions,
                         new HttpClientException("Request cancelled"),
                         callback);


### PR DESCRIPTION
Some services in PE poll services frequently and expect a high number of failures to occur during normal operations. This causes costly and concernly levels of error messages.

This moves the default for the failure messages added in 898ccc01f to the debug level. Users are advised to raise the log level of `com.puppetlabs.http.client.impl.JavaClient` to debug to see the output of spurious failures.