### PR TITLE
(maint) add clojure setup to github workflows

### DIFF
--- a/.github/workflows/clojure-linting.yaml
+++ b/.github/workflows/clojure-linting.yaml
@@ -15,6 +15,10 @@ jobs:
         with:
           distribution: temurin
           java-version: 17
+      - name: setup clojure
+        uses: DeLaGuardo/setup-clojure@13.1
+        with:
+            lein: 2.11.2                  # Leiningen
       - name: checkout repo
         uses: actions/checkout@v2
       - name: install clj-kondo (this is quite fast)

--- a/.github/workflows/pr-testing.yaml
+++ b/.github/workflows/pr-testing.yaml
@@ -24,6 +24,10 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.version }}
+      - name: setup clojure
+        uses: DeLaGuardo/setup-clojure@13.1
+        with:
+            lein: 2.11.2                  # Leiningen
       - name: clojure tests
         run: lein test
         timeout-minutes: 30


### PR DESCRIPTION
The latest ubuntu image no longer includes clojure/lein, this commit adds a step for that inclusion to the linting and PR testing workflows.